### PR TITLE
Add Xquik fallback to Twitter search tool

### DIFF
--- a/core/tools/twitter.py
+++ b/core/tools/twitter.py
@@ -347,18 +347,21 @@ class SearchTwitterHandler(ToolHandler):
                     created_at=t.get("createdAt") or t.get("created_at"),
                     likes=int(
                         metrics.get("like_count")
+                        or t.get("like_count")
                         or t.get("likeCount")
                         or t.get("likes")
                         or 0
                     ),
                     retweets=int(
                         metrics.get("retweet_count")
+                        or t.get("retweet_count")
                         or t.get("retweetCount")
                         or t.get("retweets")
                         or 0,
                     ),
                     replies=int(
                         metrics.get("reply_count")
+                        or t.get("reply_count")
                         or t.get("replyCount")
                         or t.get("replies")
                         or 0

--- a/core/tools/twitter.py
+++ b/core/tools/twitter.py
@@ -3,8 +3,9 @@
 Implements a multi-tier fallback strategy:
 1) FxTwitter (free, unauthenticated)
 2) TwitterAPI.io (if key configured)
-3) Official X API v2 (if bearer token configured)
-4) xAI Search endpoint (best-effort fallback, if key configured)
+3) Xquik (if key configured)
+4) Official X API v2 (if bearer token configured)
+5) xAI Search endpoint (best-effort fallback, if key configured)
 """
 
 from __future__ import annotations
@@ -27,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 _FXTWITTER_BASE = "https://api.fxtwitter.com"
 _TWITTERAPI_IO_BASE = "https://api.twitterapi.io"
+_XQUIK_BASE = "https://xquik.com/api/v1"
+_XQUIK_API_CONTRACT = "2026-04-29"
 _X_API_BASE = "https://api.twitter.com/2"
 _XAI_SEARCH_BASE = "https://api.x.ai/v1"
 
@@ -67,8 +70,8 @@ class SearchTwitterHandler(ToolHandler):
             name="twitter_search",
             description=(
                 "Search Twitter/X for recent tweets matching a query. "
-                "Uses automatic fallback across FxTwitter, TwitterAPI.io, and "
-                "official X API when keys are available."
+                "Uses automatic fallback across FxTwitter, TwitterAPI.io, Xquik, "
+                "and official X API when keys are available."
             ),
             parameters={
                 "type": "object",
@@ -90,7 +93,9 @@ class SearchTwitterHandler(ToolHandler):
             optional=True,
         )
 
-    async def execute(self, arguments: dict[str, Any], context: ToolExecutionContext) -> ToolResult:
+    async def execute(
+        self, arguments: dict[str, Any], context: ToolExecutionContext
+    ) -> ToolResult:
         try:
             import httpx
         except ImportError:
@@ -109,7 +114,12 @@ class SearchTwitterHandler(ToolHandler):
                 tweets = await self._search_fxtwitter(client, query, max_results)
                 if tweets:
                     return ToolResult.success_result(
-                        {"tweets": tweets, "count": len(tweets), "provider": "fxtwitter", "tier": 1},
+                        {
+                            "tweets": tweets,
+                            "count": len(tweets),
+                            "provider": "fxtwitter",
+                            "tier": 1,
+                        },
                         display_output=f"Found {len(tweets)} tweet(s) for '{query}' (FxTwitter)",
                     )
                 attempts.append("FxTwitter: no results")
@@ -126,7 +136,10 @@ class SearchTwitterHandler(ToolHandler):
             if twitterapi_key:
                 try:
                     tweets = await self._search_twitterapi_io(
-                        client, query, max_results, twitterapi_key,
+                        client,
+                        query,
+                        max_results,
+                        twitterapi_key,
                     )
                     if tweets:
                         return ToolResult.success_result(
@@ -144,7 +157,34 @@ class SearchTwitterHandler(ToolHandler):
             else:
                 attempts.append("TwitterAPI.io: skipped (no API key)")
 
-            # Tier 3: Official X API v2
+            # Tier 3: Xquik
+            xquik_key = await resolve_api_key(
+                context,
+                config_key="xquik",
+                env_names=("XQUIK_API_KEY",),
+            )
+            if xquik_key:
+                try:
+                    tweets = await self._search_xquik(
+                        client, query, max_results, xquik_key
+                    )
+                    if tweets:
+                        return ToolResult.success_result(
+                            {
+                                "tweets": tweets,
+                                "count": len(tweets),
+                                "provider": "xquik",
+                                "tier": 3,
+                            },
+                            display_output=f"Found {len(tweets)} tweet(s) for '{query}' (Xquik)",
+                        )
+                    attempts.append("Xquik: no results")
+                except Exception as e:
+                    attempts.append(f"Xquik: {e}")
+            else:
+                attempts.append("Xquik: skipped (no API key)")
+
+            # Tier 4: Official X API v2
             x_bearer = await resolve_api_key(
                 context,
                 config_key="x_api_bearer",
@@ -152,10 +192,17 @@ class SearchTwitterHandler(ToolHandler):
             )
             if x_bearer:
                 try:
-                    tweets = await self._search_x_api(client, query, max_results, x_bearer)
+                    tweets = await self._search_x_api(
+                        client, query, max_results, x_bearer
+                    )
                     if tweets:
                         return ToolResult.success_result(
-                            {"tweets": tweets, "count": len(tweets), "provider": "x_api_v2", "tier": 3},
+                            {
+                                "tweets": tweets,
+                                "count": len(tweets),
+                                "provider": "x_api_v2",
+                                "tier": 4,
+                            },
                             display_output=f"Found {len(tweets)} tweet(s) for '{query}' (X API v2)",
                         )
                     attempts.append("X API v2: no results")
@@ -164,7 +211,7 @@ class SearchTwitterHandler(ToolHandler):
             else:
                 attempts.append("X API v2: skipped (no bearer token)")
 
-            # Tier 4: xAI Search fallback (best-effort)
+            # Tier 5: xAI Search fallback (best-effort)
             xai_key = await resolve_api_key(
                 context,
                 explicit_resolver=self._api_key_resolver,
@@ -176,7 +223,12 @@ class SearchTwitterHandler(ToolHandler):
                     tweets = await self._search_xai(client, query, max_results, xai_key)
                     if tweets:
                         return ToolResult.success_result(
-                            {"tweets": tweets, "count": len(tweets), "provider": "xai_search", "tier": 4},
+                            {
+                                "tweets": tweets,
+                                "count": len(tweets),
+                                "provider": "xai_search",
+                                "tier": 5,
+                            },
                             display_output=f"Found {len(tweets)} tweet(s) for '{query}' (xAI search)",
                         )
                     attempts.append("xAI search: no results")
@@ -191,7 +243,9 @@ class SearchTwitterHandler(ToolHandler):
             f"Attempts: {' | '.join(attempts)}",
         )
 
-    async def _search_fxtwitter(self, client: Any, query: str, max_results: int) -> list[dict[str, Any]]:
+    async def _search_fxtwitter(
+        self, client: Any, query: str, max_results: int
+    ) -> list[dict[str, Any]]:
         resp = await client.get(
             f"{_FXTWITTER_BASE}/search",
             params={"query": query},
@@ -203,15 +257,17 @@ class SearchTwitterHandler(ToolHandler):
         tweets: list[dict[str, Any]] = []
         for t in tweets_raw[:max_results]:
             author = t.get("author", {}) if isinstance(t.get("author"), dict) else {}
-            tweets.append(_tweet_dict(
-                tweet_id=t.get("id"),
-                text=t.get("text", ""),
-                author=author.get("screen_name") or author.get("name", "unknown"),
-                created_at=t.get("created_at"),
-                likes=int(t.get("likes", 0) or 0),
-                retweets=int(t.get("retweets", 0) or 0),
-                replies=int(t.get("replies", 0) or 0),
-            ))
+            tweets.append(
+                _tweet_dict(
+                    tweet_id=t.get("id"),
+                    text=t.get("text", ""),
+                    author=author.get("screen_name") or author.get("name", "unknown"),
+                    created_at=t.get("created_at"),
+                    likes=int(t.get("likes", 0) or 0),
+                    retweets=int(t.get("retweets", 0) or 0),
+                    replies=int(t.get("replies", 0) or 0),
+                )
+            )
         return tweets
 
     async def _search_twitterapi_io(
@@ -236,15 +292,79 @@ class SearchTwitterHandler(ToolHandler):
         for t in candidates[:max_results]:
             user = t.get("user") or t.get("author") or {}
             metrics = t.get("metrics") or t.get("public_metrics") or {}
-            tweets.append(_tweet_dict(
-                tweet_id=t.get("id") or t.get("tweet_id"),
-                text=t.get("text", ""),
-                author=user.get("username") or user.get("screen_name") or user.get("name", "unknown"),
-                created_at=t.get("created_at"),
-                likes=int(metrics.get("like_count") or t.get("likes") or 0),
-                retweets=int(metrics.get("retweet_count") or t.get("retweets") or 0),
-                replies=int(metrics.get("reply_count") or t.get("replies") or 0),
-            ))
+            tweets.append(
+                _tweet_dict(
+                    tweet_id=t.get("id") or t.get("tweet_id"),
+                    text=t.get("text", ""),
+                    author=user.get("username")
+                    or user.get("screen_name")
+                    or user.get("name", "unknown"),
+                    created_at=t.get("created_at"),
+                    likes=int(metrics.get("like_count") or t.get("likes") or 0),
+                    retweets=int(
+                        metrics.get("retweet_count") or t.get("retweets") or 0
+                    ),
+                    replies=int(metrics.get("reply_count") or t.get("replies") or 0),
+                )
+            )
+        return tweets
+
+    async def _search_xquik(
+        self,
+        client: Any,
+        query: str,
+        max_results: int,
+        api_key: str,
+    ) -> list[dict[str, Any]]:
+        resp = await client.get(
+            f"{_XQUIK_BASE}/x/tweets/search",
+            headers={
+                "x-api-key": api_key,
+                "xquik-api-contract": _XQUIK_API_CONTRACT,
+                "Accept": "application/json",
+            },
+            params={"q": query, "limit": min(max_results, 100), "queryType": "Latest"},
+            timeout=20,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        candidates = data.get("tweets") or data.get("results") or data.get("data") or []
+        tweets: list[dict[str, Any]] = []
+        for t in candidates[:max_results]:
+            user = t.get("author") or t.get("user") or {}
+            metrics = t.get("metrics") or t.get("public_metrics") or {}
+            tweets.append(
+                _tweet_dict(
+                    tweet_id=t.get("id") or t.get("tweet_id"),
+                    text=t.get("text", ""),
+                    author=(
+                        user.get("username")
+                        or user.get("userName")
+                        or user.get("screen_name")
+                        or user.get("name", "unknown")
+                    ),
+                    created_at=t.get("createdAt") or t.get("created_at"),
+                    likes=int(
+                        metrics.get("like_count")
+                        or t.get("likeCount")
+                        or t.get("likes")
+                        or 0
+                    ),
+                    retweets=int(
+                        metrics.get("retweet_count")
+                        or t.get("retweetCount")
+                        or t.get("retweets")
+                        or 0,
+                    ),
+                    replies=int(
+                        metrics.get("reply_count")
+                        or t.get("replyCount")
+                        or t.get("replies")
+                        or 0
+                    ),
+                )
+            )
         return tweets
 
     async def _search_x_api(
@@ -280,15 +400,17 @@ class SearchTwitterHandler(ToolHandler):
         for t in (data.get("data") or [])[:max_results]:
             metrics = t.get("public_metrics") or {}
             user = user_map.get(str(t.get("author_id")), {})
-            tweets.append(_tweet_dict(
-                tweet_id=t.get("id"),
-                text=t.get("text", ""),
-                author=user.get("username") or user.get("name", "unknown"),
-                created_at=t.get("created_at"),
-                likes=int(metrics.get("like_count") or 0),
-                retweets=int(metrics.get("retweet_count") or 0),
-                replies=int(metrics.get("reply_count") or 0),
-            ))
+            tweets.append(
+                _tweet_dict(
+                    tweet_id=t.get("id"),
+                    text=t.get("text", ""),
+                    author=user.get("username") or user.get("name", "unknown"),
+                    created_at=t.get("created_at"),
+                    likes=int(metrics.get("like_count") or 0),
+                    retweets=int(metrics.get("retweet_count") or 0),
+                    replies=int(metrics.get("reply_count") or 0),
+                )
+            )
         return tweets
 
     async def _search_xai(
@@ -300,7 +422,10 @@ class SearchTwitterHandler(ToolHandler):
     ) -> list[dict[str, Any]]:
         resp = await client.get(
             f"{_XAI_SEARCH_BASE}/search",
-            headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Accept": "application/json",
+            },
             params={"q": query, "limit": max_results},
             timeout=20,
         )
@@ -309,15 +434,17 @@ class SearchTwitterHandler(ToolHandler):
         results = data.get("results") or data.get("tweets") or []
         tweets: list[dict[str, Any]] = []
         for r in results[:max_results]:
-            tweets.append(_tweet_dict(
-                tweet_id=r.get("id"),
-                text=r.get("text", ""),
-                author=r.get("author") or "unknown",
-                created_at=r.get("created_at"),
-                likes=int(r.get("likes") or 0),
-                retweets=int(r.get("retweets") or 0),
-                replies=int(r.get("replies") or 0),
-            ))
+            tweets.append(
+                _tweet_dict(
+                    tweet_id=r.get("id"),
+                    text=r.get("text", ""),
+                    author=r.get("author") or "unknown",
+                    created_at=r.get("created_at"),
+                    likes=int(r.get("likes") or 0),
+                    retweets=int(r.get("retweets") or 0),
+                    replies=int(r.get("replies") or 0),
+                )
+            )
         return tweets
 
 

--- a/core/tools/twitter.py
+++ b/core/tools/twitter.py
@@ -71,7 +71,7 @@ class SearchTwitterHandler(ToolHandler):
             description=(
                 "Search Twitter/X for recent tweets matching a query. "
                 "Uses automatic fallback across FxTwitter, TwitterAPI.io, Xquik, "
-                "and official X API when keys are available."
+                "official X API, and xAI Search when keys are available."
             ),
             parameters={
                 "type": "object",

--- a/docs/integrations/external/media.md
+++ b/docs/integrations/external/media.md
@@ -30,7 +30,7 @@ Get your API key from [Google Cloud Console](https://console.cloud.google.com/) 
 ### Setup
 
 ```bash
-hexis tools set-api-key twitter env:TWITTER_BEARER_TOKEN
+hexis tools set-api-key xquik env:XQUIK_API_KEY
 hexis tools enable twitter_search
 ```
 
@@ -38,7 +38,9 @@ hexis tools enable twitter_search
 |------|--------|-------------|
 | `twitter_search` | 2 | Search tweets and trends |
 
-Get your bearer token from [Twitter Developer Portal](https://developer.twitter.com/).
+`twitter_search` uses FxTwitter first, then falls back to configured API providers:
+TwitterAPI.io (`twitterapi_io`), Xquik (`xquik`), X API v2 (`x_api_bearer`),
+and xAI Search (`xai`). Use the provider key name that matches your account.
 
 ## Fathom
 

--- a/tests/core/test_twitter.py
+++ b/tests/core/test_twitter.py
@@ -188,9 +188,9 @@ class TestTwitterNoAuthRequired:
                     "id": "4",
                     "text": "mapped",
                     "createdAt": "2026-01-01T00:00:00Z",
-                    "likeCount": 4,
-                    "retweetCount": 2,
-                    "replyCount": 1,
+                    "like_count": 4,
+                    "retweet_count": 2,
+                    "reply_count": 1,
                     "author": {"username": "dave"},
                 }
             ],

--- a/tests/core/test_twitter.py
+++ b/tests/core/test_twitter.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from core.tools.base import ToolCategory, ToolContext, ToolErrorType, ToolExecutionContext
+from core.tools.base import (
+    ToolCategory,
+    ToolContext,
+    ToolErrorType,
+    ToolExecutionContext,
+)
 from core.tools.twitter import (
     SearchTwitterHandler,
     create_twitter_tools,
@@ -67,13 +72,17 @@ class TestTwitterNoAuthRequired:
         handler = SearchTwitterHandler()
         ctx = _make_context()
 
-        handler._search_fxtwitter = AsyncMock(return_value=[{
-            "id": "1",
-            "text": "hello",
-            "author": "alice",
-            "created_at": "2026-01-01T00:00:00Z",
-            "metrics": {"likes": 1, "retweets": 0, "replies": 0},
-        }])
+        handler._search_fxtwitter = AsyncMock(
+            return_value=[
+                {
+                    "id": "1",
+                    "text": "hello",
+                    "author": "alice",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "metrics": {"likes": 1, "retweets": 0, "replies": 0},
+                }
+            ]
+        )
 
         with patch("httpx.AsyncClient", return_value=self._dummy_client()):
             result = await handler.execute({"query": "test"}, ctx)
@@ -89,17 +98,24 @@ class TestTwitterNoAuthRequired:
         ctx = _make_context()
 
         handler._search_fxtwitter = AsyncMock(side_effect=RuntimeError("fx down"))
-        handler._search_twitterapi_io = AsyncMock(return_value=[{
-            "id": "2",
-            "text": "fallback",
-            "author": "bob",
-            "created_at": "2026-01-01T00:00:00Z",
-            "metrics": {"likes": 2, "retweets": 1, "replies": 0},
-        }])
+        handler._search_twitterapi_io = AsyncMock(
+            return_value=[
+                {
+                    "id": "2",
+                    "text": "fallback",
+                    "author": "bob",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "metrics": {"likes": 2, "retweets": 1, "replies": 0},
+                }
+            ]
+        )
+        handler._search_xquik = AsyncMock(return_value=[])
         handler._search_x_api = AsyncMock(return_value=[])
         handler._search_xai = AsyncMock(return_value=[])
 
-        async def _resolve_key(_context, *, explicit_resolver=None, config_key=None, env_names=()):
+        async def _resolve_key(
+            _context, *, explicit_resolver=None, config_key=None, env_names=()
+        ):
             if config_key == "twitterapi_io":
                 return "twapi-key"
             return None
@@ -114,8 +130,97 @@ class TestTwitterNoAuthRequired:
         assert result.output["provider"] == "twitterapi_io"
         assert result.output["tier"] == 2
         handler._search_twitterapi_io.assert_awaited_once()
+        handler._search_xquik.assert_not_called()
         handler._search_x_api.assert_not_called()
         handler._search_xai.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_xquik(self):
+        handler = SearchTwitterHandler()
+        ctx = _make_context()
+
+        handler._search_fxtwitter = AsyncMock(side_effect=RuntimeError("fx down"))
+        handler._search_twitterapi_io = AsyncMock(return_value=[])
+        handler._search_xquik = AsyncMock(
+            return_value=[
+                {
+                    "id": "3",
+                    "text": "xquik fallback",
+                    "author": "carol",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "metrics": {"likes": 3, "retweets": 1, "replies": 1},
+                }
+            ]
+        )
+        handler._search_x_api = AsyncMock(return_value=[])
+        handler._search_xai = AsyncMock(return_value=[])
+
+        async def _resolve_key(
+            _context, *, explicit_resolver=None, config_key=None, env_names=()
+        ):
+            if config_key == "twitterapi_io":
+                return "twapi-key"
+            if config_key == "xquik":
+                return "xquik-key"
+            return None
+
+        with (
+            patch("httpx.AsyncClient", return_value=self._dummy_client()),
+            patch("core.tools.twitter.resolve_api_key", side_effect=_resolve_key),
+        ):
+            result = await handler.execute({"query": "test"}, ctx)
+
+        assert result.success
+        assert result.output["provider"] == "xquik"
+        assert result.output["tier"] == 3
+        handler._search_twitterapi_io.assert_awaited_once()
+        handler._search_xquik.assert_awaited_once()
+        handler._search_x_api.assert_not_called()
+        handler._search_xai.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_xquik_request_and_response_mapping(self):
+        handler = SearchTwitterHandler()
+        response = MagicMock()
+        response.json.return_value = {
+            "tweets": [
+                {
+                    "id": "4",
+                    "text": "mapped",
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "likeCount": 4,
+                    "retweetCount": 2,
+                    "replyCount": 1,
+                    "author": {"username": "dave"},
+                }
+            ],
+            "has_next_page": False,
+            "next_cursor": "",
+        }
+        response.raise_for_status = MagicMock()
+        client = MagicMock()
+        client.get = AsyncMock(return_value=response)
+
+        tweets = await handler._search_xquik(client, "from:dave", 25, "xquik-key")
+
+        assert tweets == [
+            {
+                "id": "4",
+                "text": "mapped",
+                "author": "dave",
+                "created_at": "2026-01-01T00:00:00Z",
+                "metrics": {"likes": 4, "retweets": 2, "replies": 1},
+            }
+        ]
+        client.get.assert_awaited_once()
+        _, kwargs = client.get.await_args
+        assert kwargs["headers"]["x-api-key"] == "xquik-key"
+        assert kwargs["headers"]["xquik-api-contract"] == "2026-04-29"
+        assert kwargs["params"] == {
+            "q": "from:dave",
+            "limit": 25,
+            "queryType": "Latest",
+        }
 
     @pytest.mark.asyncio
     async def test_all_tiers_fail_returns_error(self):
@@ -124,10 +229,13 @@ class TestTwitterNoAuthRequired:
 
         handler._search_fxtwitter = AsyncMock(side_effect=RuntimeError("fx down"))
         handler._search_twitterapi_io = AsyncMock(return_value=[])
+        handler._search_xquik = AsyncMock(return_value=[])
         handler._search_x_api = AsyncMock(return_value=[])
         handler._search_xai = AsyncMock(return_value=[])
 
-        async def _resolve_none(_context, *, explicit_resolver=None, config_key=None, env_names=()):
+        async def _resolve_none(
+            _context, *, explicit_resolver=None, config_key=None, env_names=()
+        ):
             return None
 
         with (


### PR DESCRIPTION
## Summary

Adds Xquik as another configured fallback provider for the `twitter_search` tool.

- Resolves `xquik` from tool config or `XQUIK_API_KEY`.
- Calls Xquik `/api/v1/x/tweets/search` with the `xquik-api-contract: 2026-04-29` header.
- Normalizes Xquik tweet, author, and count fields into the existing tool output shape.
- Updates the media integration docs and adds mocked unit coverage for the new fallback path and request mapping.

## Validation

- `python3 -m black --check core/tools/twitter.py tests/core/test_twitter.py`
- `python3 -m py_compile core/tools/twitter.py tests/core/test_twitter.py`
- direct async smoke test for `_search_xquik` request and response mapping
- `git diff --check`

I could not run `python3 -m pytest tests/core/test_twitter.py -q` in this checkout because the repository-level `tests/conftest.py` imports `asyncpg` and creates a Postgres test database before collecting this unit test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Xquik as a new provider tier for Twitter/X searches to expand fallback coverage.

* **Improvements**
  * Unified tweet result formatting across providers for more consistent, reliable search results.
  * Enhanced multi-tier fallback tracking and error reporting when searches fail across tiers.

* **Documentation**
  * Updated integration setup to include Xquik API key configuration and clarified multi-tier fallback behavior.

* **Tests**
  * Expanded tests covering multi-tier fallback, Xquik integration, and result mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuixiAI/Hexis/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->