### PR TITLE
Experience Bar: UX hardening across CLI, chat, setup, web, and DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ logs/
 .cache/
 .tmp/
 .reference/
+.notes/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+Instructions for any AI agent working in this repo. The full repository
+guidelines live in `CLAUDE.md`; this file leads with the one thing that is
+easiest to get wrong: **the experience bar.**
+
+## The Experience Bar (applies to every user-facing change)
+
+A change is not "done" when it compiles or the test passes — it is done when the
+end-to-end experience holds. Check every user-facing change against these. Full
+text + rationale + the real failure each was learned from: `HEXIS_EXPERIENCE_BAR.md`.
+
+1. **Derive from truth — never hardcode.** If a value has a live source (models,
+   defaults, endpoints, versions), read it; don't hardcode a constant that goes stale.
+2. **The user keeps control.** No destructive/irreversible action on a timer, by
+   default, or without an explicit choice. No auto-exit, no auto-overwrite, no silent delete.
+3. **Honor the medium.** Terminal ⇒ Ctrl+C exits, native copy/paste + scrollback,
+   keyboard-first, no focus-hunting. Don't fight the platform; if a framework's
+   defaults need constant overriding, it's the wrong tool.
+4. **No dead-ends.** Every flow completes in place or hands the user the exact next
+   step. Never "quit, run this other command, come back." Errors say what/why/next.
+5. **Least surprise.** Never silently reuse ambient state the user didn't choose
+   (env creds, other tools' logins, stale config). Surface it; don't consume it.
+6. **Defaults are the expert's choice**, not the first constant that compiles.
+7. **Whole journey, not the diff.** Drive the real path a user runs, start to finish,
+   before calling it done.
+8. **Fail loud, recover gracefully.** Advisory checks never block; failures show
+   cause + fix — never a bare traceback, never a silent `except: pass`.
+
+The deeper reason these slip through one at a time (an abstraction/altitude failure)
+is written up in `why_i_suck_and_how_to_fix_it.md`.
+
+## Everything else
+
+See `CLAUDE.md` for project overview, structure, build/test commands, the venv +
+"bouncing the database" workflow, coding style, testing conventions, and safety
+notes (never revert/delete files without asking; heartbeat gating; consent flow).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,29 @@
 
 **Key principle**: The database is the brain, not just storage. State and logic live in Postgres; Python is a thin convenience layer.
 
+## The Experience Bar (IMPORTANT — applies to every user-facing change)
+
+A change is not "done" when it compiles or the test passes. It is done when the
+end-to-end experience holds. Check every user-facing change against these before
+calling it complete. Full text + rationale: `HEXIS_EXPERIENCE_BAR.md`.
+
+1. **Derive from truth — never hardcode.** If a value has a live source (models,
+   defaults, endpoints, versions), read it; don't hardcode a constant that goes stale.
+2. **The user keeps control.** No destructive/irreversible action on a timer, by
+   default, or without an explicit choice. No auto-exit, no auto-overwrite, no silent delete.
+3. **Honor the medium.** Terminal ⇒ Ctrl+C exits, native copy/paste + scrollback,
+   keyboard-first, no focus-hunting. Don't fight the platform; if a framework's
+   defaults need constant overriding, it's the wrong tool.
+4. **No dead-ends.** Every flow completes in place or hands the user the exact next
+   step. Never "quit, run this other command, come back." Errors say what/why/next.
+5. **Least surprise.** Never silently reuse ambient state the user didn't choose
+   (env creds, other tools' logins, stale config). Surface it; don't consume it.
+6. **Defaults are the expert's choice**, not the first constant that compiles.
+7. **Whole journey, not the diff.** Drive the real path a user runs, start to finish,
+   before calling it done.
+8. **Fail loud, recover gracefully.** Advisory checks never block; failures show
+   cause + fix — never a bare traceback, never a silent `except: pass`.
+
 ## Project Structure & Module Organization
 
 ```

--- a/HEXIS_EXPERIENCE_BAR.md
+++ b/HEXIS_EXPERIENCE_BAR.md
@@ -1,0 +1,67 @@
+# The Hexis Experience Bar
+
+The standard every user-facing change is checked against. A change isn't done
+until it passes every principle that applies. This is not aspirational — it's the
+definition of "done." Each principle is followed by its test and the real failure
+it was learned from.
+
+---
+
+### 1. Derive from truth — never hardcode
+Never hardcode a value that has a live source: models, defaults, capabilities,
+versions, endpoints. Read the source, cache it, fall back sensibly.
+**Test:** scan the diff for literals that should be lookups.
+*(Learned from: a stale `gpt-4o` default for every provider.)*
+
+### 2. The user keeps control
+No destructive or irreversible action on a timer, by default, or without an
+explicit choice. No auto-exit, no auto-overwrite of user data, no silent
+deletion. Timers may *inform*, never *decide*.
+**Test:** does anything happen *to* the user rather than *by* them?
+*(Learned from: the consent screen that dumped you to the shell on a countdown.)*
+
+### 3. Honor the medium
+In a terminal: Ctrl+C exits, copy/paste and scrollback are native, keyboard-first,
+no mouse or focus-hunting required. In a browser: it's a browser. Don't fight the
+platform's conventions — if a framework's defaults require constant overriding,
+the framework is wrong for the job.
+**Test:** does the user have to learn *this program's* idioms for things the
+medium already defines?
+*(Learned from: a full-screen Textual TUI that captured the mouse and rebound Ctrl+C to "copy.")*
+
+### 4. No dead-ends
+Every flow completes in place or hands the user the exact next step. Never "quit,
+run this other command, then come back." Errors state what happened, why, and the
+one thing to do next.
+**Test:** at every branch, is there always a way forward from here?
+*(Learned from: a setup wizard that told you to open a terminal and run a login command.)*
+
+### 5. Least surprise
+Never silently reuse ambient state the user didn't choose — env credentials, other
+tools' logins, stale config. Own your own state. When you *detect* something
+ambient, surface it; don't consume it.
+**Test:** would the user be surprised to learn where this value came from?
+*(Learned from: silently reusing a stale Claude Code credential.)*
+
+### 6. Defaults are the expert's choice
+The default is what a knowledgeable user would pick, not the first constant that
+compiles. Defaults are a feature, not a placeholder.
+**Test:** would someone who knows this domain accept the default without changing it?
+
+### 7. Whole journey, not the diff
+"Done" means the end-to-end experience holds — pick the option, complete the flow,
+see the result — not "the line compiles / the test passes." Drive the real path
+before calling it done.
+**Test:** did I actually run the thing a user runs, start to finish?
+*(Learned from: shipping locally-correct changes that broke the journey one level up.)*
+
+### 8. Fail loud, recover gracefully
+Advisory checks never block (a bad key surfaces with a clear message, not a wall).
+Real failures show the cause and the fix — never a bare traceback, never a silent
+`except: pass`.
+**Test:** on the worst input, does the user get a sentence they can act on?
+
+---
+
+See also `why_i_suck_and_how_to_fix_it.md` — the altitude failure that let these
+slip through one at a time instead of being caught as a class.

--- a/apps/cli_auth.py
+++ b/apps/cli_auth.py
@@ -620,8 +620,12 @@ async def _anthropic_status(dsn: str, wait_seconds: int, *, as_json: bool) -> in
         now = int(time.time() * 1000)
         expires_in_s = int((expires_at - now) / 1000) if expires_at else None
         sources.append({
+            # Detected, but Hexis does NOT use Claude Code's login (it manages
+            # its own store). Don't report it as "configured".
             "type": "claude_code",
-            "configured": True,
+            "configured": False,
+            "used_by_runtime": False,
+            "note": "detected but not used — run `hexis auth anthropic login`",
             "expires_in_seconds": expires_in_s,
             "source": cc_creds.get("source", "unknown"),
             "token_preview": cc_creds.get("accessToken", "")[-6:],
@@ -642,16 +646,20 @@ async def _anthropic_status(dsn: str, wait_seconds: int, *, as_json: bool) -> in
             sys.stdout.write("Anthropic: not configured\n")
         return 0
 
+    # "configured" for Hexis means a source the runtime actually uses.
+    usable = bool(oauth_creds or setup_creds)
     if as_json:
-        sys.stdout.write(json.dumps({"configured": True, "sources": sources}, indent=2, sort_keys=True) + "\n")
+        sys.stdout.write(json.dumps({"configured": usable, "sources": sources}, indent=2, sort_keys=True) + "\n")
     else:
+        if not usable:
+            sys.stdout.write("Anthropic: not logged in to Hexis. Run `hexis auth anthropic login`.\n")
         for src in sources:
             t = src["type"]
             if t == "oauth_pkce":
                 sys.stdout.write(f"  OAuth PKCE: expires_in={src['expires_in_seconds']}s\n")
             elif t == "claude_code":
                 exp = f" expires_in={src['expires_in_seconds']}s" if src.get("expires_in_seconds") is not None else ""
-                sys.stdout.write(f"  Claude Code: source={src['source']}{exp}\n")
+                sys.stdout.write(f"  Claude Code: detected but NOT used by Hexis ({src['source']}{exp})\n")
             elif t == "setup_token":
                 sys.stdout.write(f"  Setup token: {src['token_prefix']}\n")
     return 0
@@ -693,7 +701,11 @@ async def _chutes_login(dsn: str, wait_seconds: int, args: Any) -> int:
 
     client_id = getattr(args, "client_id", None) or os.getenv("CHUTES_CLIENT_ID", "")
     if not client_id:
-        _print_err("Chutes requires CHUTES_CLIENT_ID env var or --client-id flag.")
+        _print_err(
+            "Chutes OAuth needs a client id. Create one at https://chutes.ai (developer "
+            "settings), then set CHUTES_CLIENT_ID (or pass --client-id). Alternatively, "
+            "use Chutes as an OpenAI-compatible endpoint with an API key."
+        )
         return 1
 
     redirect_uri = os.getenv("CHUTES_REDIRECT_URI", "http://localhost:11435/auth/callback")

--- a/apps/cli_chat.py
+++ b/apps/cli_chat.py
@@ -1,18 +1,21 @@
 """Hexis CLI chat — streaming conversation via AgentLoop.
 
-Supports:
-  - Token-by-token streaming with rich rendering
+A plain, line-based streaming REPL: your terminal owns the mouse/scrollback/copy,
+Ctrl+C interrupts a reply. Features:
+  - Token-by-token streaming; leaked <think>/tool-call scaffolding is stripped
+    from the visible output (not just from what's persisted)
   - Tool call visibility as inline dim text
-  - Markdown rendering for assistant responses
-  - Slash commands: /clear, /recall <q>, /status, /quit, /verbose, /debug
-  - --verbose flag to show hydrated context and tool I/O
-  - --debug flag to also dump the full system prompt and LLM request
+  - Slash commands (type /help for the full list)
+  - --verbose shows hydrated context and tool I/O
+  - --debug also dumps the system prompt and LLM request
+  - --greet seeds a first "wake up" turn (used right after init)
 """
 from __future__ import annotations
 
 import argparse
 import asyncio
 import json
+import logging
 import os
 import sys
 import uuid
@@ -21,6 +24,51 @@ from typing import Any
 from dotenv import load_dotenv
 
 from apps.cli_theme import console, err_console
+
+logger = logging.getLogger(__name__)
+
+# Single source of truth for slash commands (drives /help + the greeting).
+COMMANDS: list[tuple[str, str]] = [
+    ("/help", "show this list"),
+    ("/recall <q>", "search long-term memory"),
+    ("/status", "agent status — energy, mood, consent"),
+    ("/tools", "list available tools"),
+    ("/history", "show this session's turns"),
+    ("/clear", "reset local context (keeps long-term memory)"),
+    ("/verbose", "toggle context + tool I/O"),
+    ("/debug", "toggle full debug"),
+    ("/prompt", "print the system prompt"),
+    ("/quit", "exit (or Ctrl+C)"),
+]
+
+
+def _print_commands() -> None:
+    console.print("[muted]Commands:[/muted]")
+    for name, desc in COMMANDS:
+        console.print(f"  [teal]{name:<12}[/teal] [muted]{desc}[/muted]")
+    console.print()
+
+
+async def _approve_tool(tool_name: str, arguments: dict[str, Any]) -> bool:
+    """Human [y/N] gate for side-effecting tools (email, DMs, shell, …).
+
+    A person being at the keyboard is NOT approval of a specific irreversible
+    act (Bar #2). Denies on EOF/Ctrl+C — the safe default.
+    """
+    console.print()
+    console.print(f"[warn]⚠ The agent wants to run:[/warn] [bold]{tool_name}[/bold]")
+    args_preview = _fmt_json(arguments, 600)
+    if args_preview and args_preview not in ("{}", "null"):
+        console.print(f"[muted]{args_preview}[/muted]")
+    try:
+        console.print("[accent]Allow this? [y/N][/accent] ", end="")
+        answer = input().strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        console.print("\n[muted]Denied.[/muted]")
+        return False
+    approved = answer in ("y", "yes")
+    console.print("[ok]Allowed.[/ok]" if approved else "[muted]Denied.[/muted]")
+    return approved
 
 
 def _fmt_json(obj: Any, max_len: int = 400) -> str:
@@ -60,22 +108,36 @@ def _print_debug_panel(title: str, content: str, *, style: str = "blue") -> None
     ))
 
 
-async def _run_chat(dsn: str, *, verbose: bool = False, debug: bool = False) -> int:
+async def _run_chat(dsn: str, *, verbose: bool = False, debug: bool = False,
+                    greet: bool = False) -> int:
     import asyncpg
+    from apps.tui.textkit import strip_scaffolding
+    from apps.tui.tips import mark_seen, random_tip, seen
     from core.agent_api import get_agent_profile_context
     from core.agent_loop import AgentEvent
     from core.cognitive_memory_api import CognitiveMemory
     from core.llm_config import load_llm_config
     from core.tools import ToolContext, create_default_registry
     from services.agent import stream_agent
-    from services.chat import _build_system_prompt, _remember_conversation
+    from services.chat import _build_system_prompt, _remember_conversation, _conversation_source_identity
     from rich.panel import Panel
     from rich.table import Table
 
     pool = await asyncpg.create_pool(dsn, min_size=2, max_size=5)
     history: list[dict[str, Any]] = []
+    # One stable id for the whole REPL session so per-turn memory dedup works
+    # (the per-turn stream session id below is separate — it keys each agent run).
+    chat_session_id = str(uuid.uuid4())
 
     try:
+        # First-run detection — an unconfigured agent can't answer.
+        async with pool.acquire() as conn:
+            try:
+                if not bool(await conn.fetchval("SELECT is_agent_configured()")):
+                    return 2
+            except Exception:
+                pass  # never block chat on this probe
+
         # Load config once
         async with pool.acquire() as conn:
             llm_config = await load_llm_config(conn, "llm.chat", fallback_key="llm")
@@ -96,7 +158,11 @@ async def _run_chat(dsn: str, *, verbose: bool = False, debug: bool = False) -> 
             mode_flags.append("debug")
         if mode_flags:
             console.print(f"[muted]Mode: {', '.join(mode_flags)} — showing {'full prompt + ' if debug else ''}hydrated context and tool I/O[/muted]")
-        console.print("[muted]Type /quit to exit, /clear to reset, /recall <q> to search, /verbose or /debug to toggle[/muted]\n")
+        console.print("[muted]Type /help for commands. Ctrl+C interrupts a reply; again (or /quit) to exit.[/muted]")
+        if not seen("chat.opened"):
+            mark_seen("chat.opened")
+            console.print("[muted]This is a normal terminal — select text to copy, scroll with your terminal.[/muted]")
+        console.print(f"[muted]{random_tip()}[/muted]\n")
 
         # Debug: show system prompt and LLM config on startup
         if debug:
@@ -112,112 +178,122 @@ async def _run_chat(dsn: str, *, verbose: bool = False, debug: bool = False) -> 
             )
 
         while True:
-            try:
-                console.print("[accent]you:[/accent] ", end="")
-                user_input = input().strip()
-            except (EOFError, KeyboardInterrupt):
-                console.print("\n[muted]Goodbye.[/muted]")
-                break
+            was_greet = False
+            if greet:
+                # Seed the first turn so the agent wakes and (with consent, no
+                # external lookups) offers to learn who you are.
+                greet = False
+                was_greet = True
+                user_input = (
+                    "Hi — this is the first time we're talking. Please introduce "
+                    "yourself briefly, and if you'd like, feel free to ask a little "
+                    "about me — only what I choose to share, and without looking "
+                    "anything up unless I say it's okay."
+                )
+                console.print(f"[accent]you:[/accent] [dim]{user_input}[/dim]")
+            else:
+                try:
+                    console.print("[accent]you:[/accent] ", end="")
+                    user_input = input().strip()
+                except (EOFError, KeyboardInterrupt):
+                    console.print("\n[muted]Goodbye.[/muted]")
+                    break
 
             if not user_input:
                 continue
 
-            # Slash commands
+            # Slash commands — one failing command must never crash the session.
             if user_input.startswith("/"):
                 cmd_parts = user_input.split(maxsplit=1)
                 cmd = cmd_parts[0].lower()
+                try:
+                    if cmd in ("/quit", "/exit"):
+                        console.print("[muted]Goodbye.[/muted]")
+                        break
 
-                if cmd in ("/quit", "/exit"):
-                    console.print("[muted]Goodbye.[/muted]")
-                    break
+                    elif cmd == "/help":
+                        _print_commands()
 
-                elif cmd == "/clear":
-                    history.clear()
-                    console.print("[muted]Conversation cleared.[/muted]\n")
-                    continue
+                    elif cmd == "/clear":
+                        history.clear()
+                        console.print("[muted]Local context reset (long-term memories are kept).[/muted]\n")
 
-                elif cmd == "/recall":
-                    query = cmd_parts[1] if len(cmd_parts) > 1 else ""
-                    if not query:
-                        err_console.print("[fail]Usage: /recall <query>[/fail]")
-                        continue
-                    async with CognitiveMemory.connect(dsn) as mem:
-                        result = await mem.recall(query, limit=5)
-                    if not result.memories:
-                        console.print("[muted]No memories found.[/muted]\n")
-                    else:
-                        for m in result.memories:
-                            content = m.content[:100] + "..." if len(m.content) > 100 else m.content
-                            console.print(f"  [teal]{m.type}[/teal] {content} [muted](sim: {m.similarity:.2f})[/muted]")
-                        console.print()
-                    continue
+                    elif cmd == "/recall":
+                        query = cmd_parts[1] if len(cmd_parts) > 1 else ""
+                        if not query:
+                            err_console.print("[fail]Usage: /recall <query>[/fail]")
+                        else:
+                            async with CognitiveMemory.connect(dsn) as mem:
+                                result = await mem.recall(query, limit=5)
+                            if not result.memories:
+                                console.print("[muted]No memories found.[/muted]\n")
+                            else:
+                                for m in result.memories:
+                                    content = m.content[:100] + "..." if len(m.content) > 100 else m.content
+                                    console.print(f"  [teal]{m.type}[/teal] {content} [muted](sim: {m.similarity:.2f})[/muted]")
+                                console.print()
 
-                elif cmd == "/status":
-                    from core.cli_api import status_payload_rich
-                    from apps.hexis_cli import _print_rich_status
-                    payload = await status_payload_rich(dsn)
-                    _print_rich_status(payload)
-                    continue
+                    elif cmd == "/status":
+                        from core.cli_api import status_payload_rich
+                        from apps.hexis_cli import _print_rich_status
+                        payload = await status_payload_rich(dsn)
+                        _print_rich_status(payload)
 
-                elif cmd == "/verbose":
-                    verbose = not verbose
-                    console.print(f"[muted]Verbose mode: {'on' if verbose else 'off'}[/muted]\n")
-                    continue
+                    elif cmd == "/verbose":
+                        verbose = not verbose
+                        console.print(f"[muted]Verbose mode: {'on' if verbose else 'off'}[/muted]\n")
 
-                elif cmd == "/debug":
-                    debug = not debug
-                    verbose = verbose or debug  # debug implies verbose
-                    console.print(f"[muted]Debug mode: {'on' if debug else 'off'} (verbose: {'on' if verbose else 'off'})[/muted]\n")
-                    if debug:
+                    elif cmd == "/debug":
+                        debug = not debug
+                        verbose = verbose or debug  # debug implies verbose
+                        console.print(f"[muted]Debug mode: {'on' if debug else 'off'} (verbose: {'on' if verbose else 'off'})[/muted]\n")
+                        if debug:
+                            _print_debug_panel(
+                                f"System Prompt ({len(system_prompt)} chars)",
+                                system_prompt, style="magenta",
+                            )
+
+                    elif cmd == "/prompt":
                         _print_debug_panel(
                             f"System Prompt ({len(system_prompt)} chars)",
-                            system_prompt,
-                            style="magenta",
+                            system_prompt, style="magenta",
                         )
-                    continue
 
-                elif cmd == "/prompt":
-                    _print_debug_panel(
-                        f"System Prompt ({len(system_prompt)} chars)",
-                        system_prompt,
-                        style="magenta",
-                    )
-                    continue
-
-                elif cmd == "/tools":
-                    specs = await registry.get_specs(ToolContext.CHAT)
-                    table = Table(title="Available Tools", show_lines=False, border_style="dim")
-                    table.add_column("Name", style="teal")
-                    table.add_column("Description", style="dim", max_width=80)
-                    for spec in specs:
-                        func = spec.get("function", {})
-                        table.add_row(func.get("name", "?"), _truncate(func.get("description", ""), 80))
-                    console.print(table)
-                    console.print()
-                    continue
-
-                elif cmd == "/history":
-                    if not history:
-                        console.print("[muted]No conversation history yet.[/muted]\n")
-                    else:
-                        for i, msg in enumerate(history):
-                            role = msg["role"]
-                            content = _truncate(msg["content"], 120)
-                            console.print(f"  [dim]{i}[/dim] [teal]{role}[/teal]: {content}")
+                    elif cmd == "/tools":
+                        specs = await registry.get_specs(ToolContext.CHAT)
+                        table = Table(title="Available Tools", show_lines=False, border_style="dim")
+                        table.add_column("Name", style="teal")
+                        table.add_column("Description", style="dim", max_width=80)
+                        for spec in specs:
+                            func = spec.get("function", {})
+                            table.add_row(func.get("name", "?"), _truncate(func.get("description", ""), 80))
+                        console.print(table)
                         console.print()
-                    continue
 
-                else:
-                    err_console.print(f"[fail]Unknown command: {cmd}[/fail]")
-                    err_console.print("[muted]Commands: /quit /clear /recall /status /verbose /debug /prompt /tools /history[/muted]")
-                    continue
+                    elif cmd == "/history":
+                        if not history:
+                            console.print("[muted]No conversation history yet.[/muted]\n")
+                        else:
+                            for i, msg in enumerate(history):
+                                console.print(f"  [dim]{i}[/dim] [teal]{msg['role']}[/teal]: {_truncate(msg['content'], 120)}")
+                            console.print()
+
+                    else:
+                        err_console.print(f"[fail]Unknown command: {cmd}[/fail]")
+                        _print_commands()
+                except Exception as e:
+                    err_console.print(f"[fail]{cmd} failed: {e}[/fail]")
+                    err_console.print("[muted]Your conversation is intact — try again or /help.[/muted]")
+                continue
 
             # Normal message — stream response via unified agent runner
             # (subconscious pre-phase → memory hydration → conscious loop)
             session_id = str(uuid.uuid4())
 
             try:
-                full_text = ""
+                raw_buf = ""   # full raw model output
+                shown = ""     # what we've actually printed (scaffolding-stripped)
+                turn_timed_out = False
                 tool_calls_log: list[dict[str, Any]] = []
 
                 # Debug: show conversation history being sent
@@ -242,6 +318,7 @@ async def _run_chat(dsn: str, *, verbose: bool = False, debug: bool = False) -> 
                     session_id=session_id,
                     agent_profile=agent_profile,
                     dsn=dsn,
+                    on_approval=_approve_tool,
                 ):
                     if event.event == AgentEvent.PHASE_CHANGE:
                         phase = event.data.get("phase", "")
@@ -260,9 +337,19 @@ async def _run_chat(dsn: str, *, verbose: bool = False, debug: bool = False) -> 
                     elif event.event == AgentEvent.TEXT_DELTA:
                         text = event.data.get("text", "")
                         if text:
-                            full_text += text
-                            sys.stdout.write(text)
-                            sys.stdout.flush()
+                            raw_buf += text
+                            # Strip leaked <think>/tool-call scaffolding from what the
+                            # user SEES, not just from what we persist. Streaming-safe:
+                            # only emit newly-revealed prose (partial tags are held back).
+                            visible = strip_scaffolding(raw_buf)[0]
+                            if visible.startswith(shown):
+                                new = visible[len(shown):]
+                                if new:
+                                    sys.stdout.write(new)
+                                    sys.stdout.flush()
+                                    shown = visible
+                            else:
+                                shown = visible
 
                     elif event.event == AgentEvent.TOOL_START:
                         tool_name = event.data.get("tool_name", "tool")
@@ -295,14 +382,14 @@ async def _run_chat(dsn: str, *, verbose: bool = False, debug: bool = False) -> 
                             console.print(f"\n  [dim]Loop started: {tool_count} tools, energy={energy}[/dim]")
 
                     elif event.event == AgentEvent.LOOP_END:
+                        turn_timed_out = bool(event.data.get("timed_out", False))
                         if debug:
                             reason = event.data.get("stopped_reason", "?")
                             iters = event.data.get("iterations", 0)
                             energy_spent = event.data.get("energy_spent", 0)
-                            timed_out = event.data.get("timed_out", False)
                             console.print(
                                 f"  [dim]Loop ended: reason={reason}, iterations={iters}, "
-                                f"energy_spent={energy_spent}{', TIMED OUT' if timed_out else ''}[/dim]"
+                                f"energy_spent={energy_spent}{', TIMED OUT' if turn_timed_out else ''}[/dim]"
                             )
 
                     elif event.event == AgentEvent.ERROR:
@@ -320,26 +407,60 @@ async def _run_chat(dsn: str, *, verbose: bool = False, debug: bool = False) -> 
                     )
                     console.print(f"[dim]Tool calls this turn:\n{summary}[/dim]")
 
+                clean_text = strip_scaffolding(raw_buf)[0].strip() if raw_buf else ""
+
+                if turn_timed_out:
+                    console.print("[warn](response timed out — the reply above may be incomplete)[/warn]")
+
+                # Empty response — say so, don't poison history with a blank turn.
+                if not clean_text:
+                    console.print(
+                        "[muted](the model returned an empty response — try rephrasing, "
+                        "or check the connection with `hexis doctor --llm`)[/muted]\n"
+                    )
+                    continue
+
                 console.print()
 
-                # Update history
-                history.append({"role": "user", "content": user_input})
-                history.append({"role": "assistant", "content": full_text})
+                # Update history. On the first-run greet, keep the agent's intro
+                # for context but do NOT record the fabricated wake-nudge as the
+                # user's words (in history or in long-term memory).
+                if not was_greet:
+                    history.append({"role": "user", "content": user_input})
+                history.append({"role": "assistant", "content": clean_text})
 
-                # Memory formation
-                if full_text:
-                    try:
-                        async with CognitiveMemory.connect(dsn) as mem_client:
-                            await _remember_conversation(
-                                mem_client,
-                                user_message=user_input,
-                                assistant_message=full_text,
-                            )
-                    except Exception:
-                        pass
+                if was_greet:
+                    continue
 
+                # Memory formation (advisory — never blocks, but fails loud in logs).
+                # Pass a stable dedup key so an identical turn isn't stored twice.
+                src_id = _conversation_source_identity(
+                    chat_session_id, history, user_input, clean_text
+                )
+                try:
+                    async with CognitiveMemory.connect(dsn) as mem_client:
+                        await _remember_conversation(
+                            mem_client,
+                            user_message=user_input,
+                            assistant_message=clean_text,
+                            session_id=chat_session_id,
+                            source_identity=src_id,
+                        )
+                except Exception:
+                    logger.warning("memory formation failed", exc_info=True)
+                    if debug:
+                        err_console.print("[muted](memory not stored this turn — see logs)[/muted]")
+
+            except KeyboardInterrupt:
+                sys.stdout.write("\n")
+                console.print("[muted](interrupted)[/muted]\n")
+                continue
             except Exception as e:
-                err_console.print(f"\n[fail]Error: {e}[/fail]\n")
+                err_console.print(f"\n[fail]Something went wrong: {e}[/fail]")
+                err_console.print(
+                    "[muted]Your conversation is intact. Try again, or run "
+                    "`hexis doctor --llm` to check the model connection.[/muted]\n"
+                )
 
     finally:
         await pool.close()
@@ -355,6 +476,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--dsn", default=None, help="Postgres DSN; defaults to POSTGRES_* env vars")
     p.add_argument("-v", "--verbose", action="store_true", help="Show hydrated context and tool I/O")
     p.add_argument("-d", "--debug", action="store_true", help="Full debug: system prompt, enriched messages, LLM config, tool specs")
+    p.add_argument("--greet", action="store_true", help="Seed a first 'wake up' turn (used right after init)")
     return p
 
 
@@ -368,13 +490,28 @@ def main(argv: list[str] | None = None) -> int:
     debug = args.debug
 
     try:
-        return asyncio.run(_run_chat(dsn, verbose=verbose, debug=debug))
+        rc = asyncio.run(_run_chat(dsn, verbose=verbose, debug=debug, greet=args.greet))
     except KeyboardInterrupt:
         console.print("\n[muted]Goodbye.[/muted]")
         return 0
     except Exception as e:
         err_console.print(f"[fail]Chat failed: {e}[/fail]")
         return 1
+
+    # First-run: agent not configured → offer setup (sync layer, no nested loop).
+    if rc == 2:
+        console.print("\n[warn]No agent is configured yet.[/warn]")
+        try:
+            console.print("[accent]Run setup (hexis init) now? [Y/n][/accent] ", end="")
+            answer = input().strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            answer = "n"
+        if answer in ("", "y", "yes"):
+            from apps import hexis_init
+            return hexis_init.main([])
+        console.print("[muted]Run `hexis init` to set up your agent.[/muted]")
+        return 0
+    return rc
 
 
 if __name__ == "__main__":

--- a/apps/cli_prompts.py
+++ b/apps/cli_prompts.py
@@ -1,0 +1,77 @@
+"""Line-based prompt helpers (questionary) for the Hexis CLI wizard.
+
+Keyboard-first, native-terminal prompts: arrow-key selects, text entry with
+readline, confirms. Ctrl+C raises ``KeyboardInterrupt`` (via ``unsafe_ask``) so
+the caller's handler exits cleanly — the way a terminal program should behave.
+"""
+from __future__ import annotations
+
+import re
+
+import questionary
+from questionary import Choice, Style
+
+# Match the Hexis palette (burnt orange + teal).
+_STYLE = Style([
+    ("qmark", "fg:#d8774f bold"),
+    ("question", "bold"),
+    ("pointer", "fg:#d8774f bold"),
+    ("highlighted", "fg:#d8774f bold"),
+    ("selected", "fg:#3c6f64"),
+    ("answer", "fg:#3c6f64 bold"),
+    ("instruction", "fg:#8a8a8a"),
+])
+
+_MARKUP = re.compile(r"\[/?[^\]]*\]")
+
+
+def _plain(s: str) -> str:
+    """Strip Rich markup so questionary shows clean labels."""
+    return _MARKUP.sub("", s).strip()
+
+
+# All prompts are async (``ask_async``) so they run in the caller's already-
+# running event loop — the wizard is async (asyncpg), and questionary's sync
+# API would try to start a nested loop and fail.
+
+async def select_index(message: str, options: list[str], *, default: int = 1) -> int:
+    """Arrow-key select over *options*; returns the 1-based index chosen."""
+    choices = [Choice(title=_plain(o), value=i) for i, o in enumerate(options, 1)]
+    default_choice = choices[default - 1] if 1 <= default <= len(choices) else None
+    return await questionary.select(
+        _plain(message), choices=choices, default=default_choice,
+        style=_STYLE, qmark="?", instruction="(↑/↓, Enter)",
+    ).unsafe_ask_async()
+
+
+async def select_value(message: str, pairs: list[tuple[str, object]], *, default_value=None):
+    """Arrow-key select; *pairs* are (label, value). Returns the chosen value."""
+    choices = [Choice(title=_plain(label), value=val) for label, val in pairs]
+    default_choice = next((c for c in choices if c.value == default_value), None)
+    return await questionary.select(
+        _plain(message), choices=choices, default=default_choice,
+        style=_STYLE, qmark="?", instruction="(↑/↓, Enter)",
+    ).unsafe_ask_async()
+
+
+async def text(message: str, *, default: str = "") -> str:
+    return await questionary.text(_plain(message), default=default or "",
+                                  style=_STYLE, qmark="?").unsafe_ask_async()
+
+
+async def autocomplete(message: str, options: list[str], *, default: str = "") -> str:
+    """Type-to-filter over *options* but any free-typed value is accepted."""
+    return await questionary.autocomplete(
+        _plain(message), choices=list(options), default=default or "",
+        style=_STYLE, qmark="?", ignore_case=True,
+    ).unsafe_ask_async()
+
+
+async def confirm(message: str, *, default: bool = False) -> bool:
+    return await questionary.confirm(_plain(message), default=default,
+                                     style=_STYLE, qmark="?").unsafe_ask_async()
+
+
+async def password(message: str) -> str:
+    return await questionary.password(_plain(message), style=_STYLE,
+                                      qmark="?").unsafe_ask_async()

--- a/apps/hexis_api.py
+++ b/apps/hexis_api.py
@@ -481,6 +481,49 @@ async def _apply_existing_consent(conn, record: dict[str, Any]) -> dict[str, Any
     return {"status": next_status}
 
 
+class InitConsentOverrideRequest(BaseModel):
+    role: Literal["conscious", "subconscious"] = "conscious"
+    llm: ConsentLlmConfig | None = None
+    model_decision: str = "decline"
+
+
+@app.post("/api/init/consent/override")
+async def init_consent_override(req: InitConsentOverrideRequest):
+    """Owner override: proceed and activate even though the model didn't consent.
+
+    Consent is a signal, not a lock — it's the owner's AI. The model's response is
+    preserved in the recorded signature; the owner's choice to proceed is explicit.
+    """
+    pool = _pool
+    if pool is None:
+        return JSONResponse({"error": "Server not ready (no DB pool)"}, status_code=503)
+
+    from core.llm import normalize_provider
+    from core.init_api import record_consent_override
+
+    llm = req.llm or ConsentLlmConfig()
+    provider = normalize_provider((llm.provider or "").strip().lower() or "openai")
+    model = (llm.model or "").strip()
+    endpoint = (llm.endpoint or "").strip() or None
+    if provider in {"anthropic", "grok", "gemini"}:
+        endpoint = None
+    if not model:
+        return JSONResponse({"error": "Missing model"}, status_code=400)
+
+    async with pool.acquire() as conn:
+        result = await record_consent_override(
+            conn,
+            {"provider": provider, "model": model, "endpoint": endpoint},
+            model_decision=(req.model_decision or "decline"),
+        )
+        status_raw = await conn.fetchval("SELECT get_init_status() as status")
+        status = (
+            status_raw if isinstance(status_raw, dict)
+            else (json.loads(status_raw) if isinstance(status_raw, str) else {})
+        )
+    return JSONResponse({"decision": "consent", "override": True, "result": result, "status": status})
+
+
 @app.post("/api/init/consent/request")
 async def init_consent_request(req: InitConsentRequest):
     pool = _pool

--- a/apps/hexis_cli.py
+++ b/apps/hexis_cli.py
@@ -396,6 +396,7 @@ def build_parser() -> argparse.ArgumentParser:
     doctor = sub.add_parser("doctor", parents=[_db], help="Diagnose common issues")
     doctor.add_argument("--json", action="store_true", help="Output JSON")
     doctor.add_argument("--demo", action="store_true", help="Run end-to-end sanity check against the DB")
+    doctor.add_argument("--llm", action="store_true", help="Make one real LLM call to verify provider/model/key")
     doctor.set_defaults(func="doctor")
 
     # Hidden alias: 'demo' → 'doctor --demo'
@@ -689,6 +690,21 @@ async def _tools_list(dsn: str, context_filter: str | None, as_json: bool) -> in
         await pool.close()
 
 
+def _check_tool_name(pool, tool_name: str) -> bool:
+    """Validate a tool name against the registry so typos don't silently
+    'succeed' (Bar #4, #8). Returns True if valid; prints guidance if not."""
+    from core.tools import create_default_registry
+    import difflib
+
+    names = sorted(h.spec.name for h in create_default_registry(pool).list_all())
+    if tool_name in names:
+        return True
+    close = difflib.get_close_matches(tool_name, names, n=3)
+    hint = f" Did you mean: {', '.join(close)}?" if close else ""
+    _print_err(f"Unknown tool '{tool_name}'.{hint} Run `hexis tools list` to see them all.")
+    return False
+
+
 async def _tools_enable(dsn: str, tool_name: str) -> int:
     """Enable a tool."""
     import asyncpg
@@ -696,6 +712,8 @@ async def _tools_enable(dsn: str, tool_name: str) -> int:
 
     pool = await asyncpg.create_pool(dsn, min_size=1, max_size=2)
     try:
+        if not _check_tool_name(pool, tool_name):
+            return 1
         config = await load_tools_config(pool)
 
         # Add to enabled list (or create it)
@@ -709,7 +727,8 @@ async def _tools_enable(dsn: str, tool_name: str) -> int:
             config.disabled.remove(tool_name)
 
         await save_tools_config(pool, config)
-        sys.stdout.write(f"Enabled tool: {tool_name}\n")
+        from apps.cli_theme import console as _con
+        _con.print(f"[ok]✔[/ok] Enabled tool: [bold]{tool_name}[/bold]")
         return 0
     finally:
         await pool.close()
@@ -722,6 +741,8 @@ async def _tools_disable(dsn: str, tool_name: str) -> int:
 
     pool = await asyncpg.create_pool(dsn, min_size=1, max_size=2)
     try:
+        if not _check_tool_name(pool, tool_name):
+            return 1
         config = await load_tools_config(pool)
 
         # Add to disabled list
@@ -733,7 +754,8 @@ async def _tools_disable(dsn: str, tool_name: str) -> int:
             config.enabled.remove(tool_name)
 
         await save_tools_config(pool, config)
-        sys.stdout.write(f"Disabled tool: {tool_name}\n")
+        from apps.cli_theme import console as _con
+        _con.print(f"[ok]✔[/ok] Disabled tool: [bold]{tool_name}[/bold]")
         return 0
     finally:
         await pool.close()
@@ -752,7 +774,8 @@ async def _tools_set_api_key(dsn: str, key_name: str, value: str) -> int:
 
         # Redact display value
         display_val = value if value.startswith("env:") else "***"
-        sys.stdout.write(f"Set API key: {key_name} = {display_val}\n")
+        from apps.cli_theme import console as _con
+        _con.print(f"[ok]✔[/ok] Set API key: [bold]{key_name}[/bold] = [muted]{display_val}[/muted]")
         return 0
     finally:
         await pool.close()
@@ -765,10 +788,13 @@ async def _tools_set_cost(dsn: str, tool_name: str, cost: int) -> int:
 
     pool = await asyncpg.create_pool(dsn, min_size=1, max_size=2)
     try:
+        if not _check_tool_name(pool, tool_name):
+            return 1
         config = await load_tools_config(pool)
         config.costs[tool_name] = cost
         await save_tools_config(pool, config)
-        sys.stdout.write(f"Set energy cost: {tool_name} = {cost}\n")
+        from apps.cli_theme import console as _con
+        _con.print(f"[ok]✔[/ok] Set energy cost: [bold]{tool_name}[/bold] = [bold]{cost}[/bold]")
         return 0
     finally:
         await pool.close()
@@ -1008,7 +1034,7 @@ async def _instance_delete(name: str, force: bool, reason: str | None) -> int:
         sys.stdout.flush()
         try:
             confirmation = input()
-        except EOFError:
+        except (EOFError, KeyboardInterrupt):
             _print_err("Aborted.")
             return 1
 
@@ -1600,7 +1626,10 @@ async def _channels_status(dsn: str, as_json: bool) -> int:
         return 0
     except Exception as e:
         if "channel_sessions" in str(e):
-            _print_err("Channel tables not found. Bounce the DB to apply schema: docker-compose down -v && docker-compose build db && docker-compose up -d")
+            _print_err(
+                "Channel tables not found — your schema is out of date. "
+                "Run `hexis reset` to rebuild it (it will confirm before wiping data)."
+            )
         else:
             _print_err(f"Error: {e}")
         return 1
@@ -1747,6 +1776,9 @@ async def _channels_setup(dsn: str, channel_type: str) -> int:
             sys.stdout.write("Start with: hexis channels start --channel matrix\n")
 
         return 0
+    except (KeyboardInterrupt, EOFError):
+        _print_err("Aborted.")
+        return 1
     except Exception as e:
         _print_err(f"Error: {e}")
         return 1
@@ -2122,6 +2154,28 @@ async def _schedule_delete(dsn: str, task_id: str, force: bool) -> int:
         await pool.close()
 
 
+def _port_ready(port: int, host: str = "127.0.0.1", timeout: float = 0.5) -> bool:
+    """True if something accepts a TCP connection on host:port."""
+    import socket
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _wait_port_ready(port: int, host: str = "127.0.0.1", overall: float = 45.0) -> bool:
+    """Poll until the port accepts connections (or time out). Beats a fixed
+    sleep before opening a browser at a cold Next.js build (Bar #4)."""
+    import time as _time
+    deadline = _time.monotonic() + overall
+    while _time.monotonic() < deadline:
+        if _port_ready(port, host):
+            return True
+        _time.sleep(0.4)
+    return False
+
+
 def _handle_ui(stack_root: Path, port: int, no_open: bool) -> int:
     """Start the Next.js web dashboard."""
     import threading
@@ -2228,11 +2282,11 @@ def _handle_ui(stack_root: Path, port: int, no_open: bool) -> int:
     from apps.cli_theme import console
     console.print(f"\n[accent]Starting web dashboard on port {port}...[/accent]")
 
-    # Open browser after a short delay
+    # Open the browser only once the server actually responds — not on a timer.
     if not no_open:
         def _open_browser():
-            time.sleep(3)
-            webbrowser.open(f"http://localhost:{port}")
+            if _wait_port_ready(port):
+                webbrowser.open(f"http://localhost:{port}")
         t = threading.Thread(target=_open_browser, daemon=True)
         t.start()
 
@@ -2330,11 +2384,11 @@ def _handle_ui_container(
         _print_err("Failed to start UI container.")
         return rc
 
-    # Open browser after a short delay
+    # Open the browser only once the server actually responds — not on a timer.
     if not no_open:
         def _open_browser():
-            time.sleep(3)
-            webbrowser.open(f"http://localhost:{port}")
+            if _wait_port_ready(port):
+                webbrowser.open(f"http://localhost:{port}")
         t = threading.Thread(target=_open_browser, daemon=True)
         t.start()
 
@@ -2350,6 +2404,29 @@ def _handle_ui_container(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Top-level guard: turn stack-down / unhandled errors into one actionable
+    line instead of a raw traceback (Experience Bar #8, #4)."""
+    try:
+        return _dispatch(argv)
+    except KeyboardInterrupt:
+        _print_err("Aborted.")
+        return 130
+    except Exception as e:  # noqa: BLE001
+        low = str(e).lower()
+        if any(s in low for s in (
+            "postgres", "connection refused", "connect call failed",
+            "failed to connect", "timed out connecting", "timeouterror",
+        )) or isinstance(e, (ConnectionError, TimeoutError)):
+            _print_err(
+                "Can't reach the database. Is the stack running? "
+                "Try `hexis up`, then `hexis doctor`."
+            )
+        else:
+            _print_err(f"Error: {e}")
+        return 1
+
+
+def _dispatch(argv: list[str] | None = None) -> int:
     load_dotenv()
 
     # Some commands intentionally forward argv to another module (init/chat/ingest/etc).
@@ -2413,29 +2490,9 @@ def main(argv: list[str] | None = None) -> int:
 
         fwd_argv = cmd_argv[1:]
 
-        # Launch Textual TUI for chat and init (unless non-interactive)
-        if cmd == "chat":
-            try:
-                from apps.tui.chat_app import HexisChatApp
-                tui_argv = [a for a in fwd_argv if a != "--"]
-                app = HexisChatApp(tui_argv)
-                app.run()
-                return 0
-            except ImportError:
-                pass
-
-        if cmd == "init":
-            _noninteractive_flags = {"--api-key", "--provider", "--character"}
-            has_noninteractive = any(f in fwd_argv for f in _noninteractive_flags)
-            if not has_noninteractive:
-                try:
-                    from apps.tui.init_app import HexisInitApp
-                    tui_argv = [a for a in fwd_argv if a != "--"]
-                    app = HexisInitApp(tui_argv)
-                    app.run()
-                    return 0
-                except ImportError:
-                    pass
+        # chat and init use line-based CLIs (apps.cli_chat / apps.hexis_init) —
+        # keyboard-first, native terminal, Ctrl+C exits. They are reached via the
+        # forward_map below.
 
         if cmd == "ingest":
             # UX/backwards-compat: accept `hexis ingest --file foo.md` by auto-inserting
@@ -2539,7 +2596,13 @@ def main(argv: list[str] | None = None) -> int:
         if not is_source:
             from apps.cli_theme import console
             console.print("[accent]Pulling Docker images...[/accent]")
-            run_compose(compose_cmd or [], compose_file, stack_root, ["pull"], env_file)
+            pull_rc = run_compose(compose_cmd or [], compose_file, stack_root, ["pull"], env_file)
+            if pull_rc != 0:
+                console.print(
+                    "[warn]⚠ Image pull failed[/warn] — check your network, `docker login`, "
+                    "or a registry rate limit. Continuing with cached images; if `up` reports a "
+                    "missing image, that's the cause."
+                )
         # Build compose args: --profile flags must come before the subcommand
         compose_extra: list[str] = []
         for profile in args.profile:
@@ -2559,9 +2622,10 @@ def main(argv: list[str] | None = None) -> int:
             except Exception:
                 pass  # never block startup
 
-            console.print("  [accent]hexis ui[/accent]     Open the web dashboard")
+            # A fresh agent must be configured before chat/ui are useful — lead with it.
+            console.print("  [accent]hexis init[/accent]   Configure the agent (start here)")
             console.print("  [accent]hexis chat[/accent]   Chat in the terminal")
-            console.print("  [accent]hexis init[/accent]   Configure the agent")
+            console.print("  [accent]hexis ui[/accent]     Open the web dashboard")
             console.print()
         return rc
     if func == "down":
@@ -2605,14 +2669,6 @@ def main(argv: list[str] | None = None) -> int:
         return run_compose(compose_cmd or [], compose_file, stack_root, log_args, env_file)
     if func == "chat":
         fwd_argv = list(args.args or [])
-        try:
-            from apps.tui.chat_app import HexisChatApp
-            tui_argv = [a for a in fwd_argv if a != "--"]
-            app = HexisChatApp(tui_argv)
-            app.run()
-            return 0
-        except ImportError:
-            pass  # textual not installed, fall through
         return _run_module("apps.cli_chat", fwd_argv)
     if func == "ingest":
         argv = list(args.args or [])
@@ -2630,18 +2686,6 @@ def main(argv: list[str] | None = None) -> int:
         return _run_module("apps.worker", args.args)
     if func == "init":
         fwd_argv = list(args.args or [])
-        # Non-interactive flags bypass TUI automatically
-        _noninteractive_flags = {"--api-key", "--provider", "--character"}
-        has_noninteractive = any(f in fwd_argv for f in _noninteractive_flags)
-        if not has_noninteractive:
-            try:
-                from apps.tui.init_app import HexisInitApp
-                tui_argv = [a for a in fwd_argv if a != "--"]
-                app = HexisInitApp(tui_argv)
-                app.run()
-                return 0
-            except ImportError:
-                pass  # textual not installed, fall through
         return _run_module("apps.hexis_init", fwd_argv)
     if func == "mcp":
         return _run_module("apps.hexis_mcp_server", args.args)
@@ -2660,6 +2704,12 @@ def main(argv: list[str] | None = None) -> int:
         return _handle_ui_container(compose_cmd_ui, compose_file, stack_root, env_file, args.port, args.no_open)
     if func == "open":
         import webbrowser
+        if not _port_ready(args.port):
+            _print_err(
+                f"Nothing is listening on http://localhost:{args.port}. "
+                "Start the dashboard first with `hexis ui`."
+            )
+            return 1
         webbrowser.open(f"http://localhost:{args.port}")
         return 0
     if func == "start":
@@ -2701,7 +2751,8 @@ def main(argv: list[str] | None = None) -> int:
         from rich.live import Live
 
         with Live(Spinner("dots", text="Running diagnostics..."), console=_con, transient=True):
-            checks = asyncio.run(cli_api.doctor_payload(dsn, wait_seconds=args.wait_seconds))
+            checks = asyncio.run(cli_api.doctor_payload(
+                dsn, wait_seconds=args.wait_seconds, check_llm=bool(getattr(args, "llm", False))))
 
         if args.json:
             sys.stdout.write(json.dumps(checks, indent=2) + "\n")
@@ -2783,11 +2834,13 @@ def main(argv: list[str] | None = None) -> int:
             _print_rich_status(payload)
         return 0
     if func == "config":
-        dsn = _get_dsn(args)
-        cfg = asyncio.run(cli_api.config_rows(dsn, wait_seconds=args.wait_seconds))
-        cfg = _redact_config(cfg)
-        sys.stdout.write(json.dumps(cfg, indent=2, sort_keys=True) + "\n")
-        return 0
+        # Bare `config` shows the grouped table like `config show` (not raw JSON),
+        # matching how `goals`/`schedule`/`channels` default to their list view.
+        if not hasattr(args, "no_redact"):
+            args.no_redact = False
+        if not hasattr(args, "json"):
+            args.json = False
+        func = "config_show"
     if func == "config_show":
         dsn = _get_dsn(args)
         cfg = asyncio.run(cli_api.config_rows(dsn, wait_seconds=args.wait_seconds))
@@ -2923,7 +2976,8 @@ def main(argv: list[str] | None = None) -> int:
         dsn = _get_dsn(args)
         return asyncio.run(_schedule_delete(dsn, args.task_id, args.force))
 
-    _print_err("Unknown command")
+    _print_err(f"Unknown command: {func}")
+    _print_grouped_help()
     return 2
 
 

--- a/apps/hexis_init.py
+++ b/apps/hexis_init.py
@@ -31,20 +31,9 @@ from apps.cli_theme import console, err_console, heading, make_panel, make_table
 # Non-interactive helpers
 # ---------------------------------------------------------------------------
 
-_DEFAULT_MODELS: dict[str, str] = {
-    "anthropic": "claude-sonnet-4-20250514",
-    "openai": "gpt-4o",
-    "openai-codex": "gpt-5.2",
-    "grok": "grok-3",
-    "gemini": "gemini-2.5-flash",
-    "ollama": "llama3.1",
-    "chutes": "deepseek-ai/DeepSeek-V3-0324",
-    "github-copilot": "gpt-4o",
-    "qwen-portal": "qwen-max-latest",
-    "minimax-portal": "MiniMax-M1",
-    "google-gemini-cli": "gemini-2.5-flash",
-    "google-antigravity": "gemini-2.5-flash",
-}
+# Default models are NOT hardcoded here — they derive from the live catalog
+# (apps/tui/model_catalog.py: models.dev + recommended_default), the single
+# source of truth shared with the interactive wizard (Bar #1).
 
 _PROVIDER_ENV_VARS: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
@@ -103,6 +92,7 @@ async def _ensure_oauth_login(
     *,
     wait_seconds: int,
     allow_manual_fallback: bool = True,
+    non_interactive: bool = False,
 ) -> None:
     """
     Ensure OAuth/device-code/token credentials exist for the given provider.
@@ -131,6 +121,13 @@ async def _ensure_oauth_login(
     existing = load_fn()
     if existing:
         return
+
+    # Non-interactive (CI/scripts) must not open a browser or block on a paste.
+    if non_interactive:
+        raise RuntimeError(
+            f"Not logged in to {provider}. Run `hexis auth {provider} login` first, "
+            "then re-run init."
+        )
 
     display = provider.replace("-", " ").title()
     console.print(f"[muted]Starting {display} login...[/muted]")
@@ -186,9 +183,11 @@ async def _load_llm_config_for_consent(
     wait_seconds: int,
     provider: str,
     model: str,
+    non_interactive: bool = False,
 ) -> dict[str, Any]:
     if provider in _OAUTH_PROVIDERS:
-        await _ensure_oauth_login(provider, dsn, conn, wait_seconds=wait_seconds)
+        await _ensure_oauth_login(provider, dsn, conn, wait_seconds=wait_seconds,
+                                  non_interactive=non_interactive)
 
     from core.llm_config import load_llm_config
 
@@ -279,8 +278,11 @@ def _ensure_embedding_model() -> None:
         if model.split(":")[0] in result.stdout:
             console.print(f"[ok]\u2714[/ok] Embedding model [bold]{model}[/bold] present")
             return
-    except Exception:
-        pass
+    except Exception as exc:
+        console.print(
+            f"[warn]\u26a0[/warn] Couldn't query Ollama ({exc}). Is it running? "
+            "Try `ollama serve`. Attempting to pull anyway\u2026"
+        )
 
     console.print(f"[muted]Pulling embedding model {model}...[/muted]")
     try:
@@ -305,17 +307,39 @@ async def _run_init_noninteractive(args: argparse.Namespace) -> int:
         else:
             provider = "ollama"
     provider = _normalize_provider_name(provider)
+    # "anthropic-oauth" is a wizard alias; the LLM layer knows "anthropic".
+    persist_provider = "anthropic" if provider == "anthropic-oauth" else provider
 
-    if provider not in (_OAUTH_PROVIDERS | {"ollama"}) and not args.api_key:
+    _no_key_needed = _OAUTH_PROVIDERS | {"ollama", "anthropic-oauth"}
+    if provider not in _no_key_needed and not args.api_key:
         err_console.print(f"[fail]--api-key required for provider '{provider}'[/fail]")
         return 1
 
-    # 2. Resolve model
-    model = args.model or _DEFAULT_MODELS.get(provider, "gpt-4o")
-    api_key_env = _PROVIDER_ENV_VARS.get(provider, "")
+    # OAuth providers can't do a browser login non-interactively — require the
+    # user to have logged in already, and fail fast with the exact command.
+    if provider == "anthropic-oauth":
+        from core.auth.anthropic_oauth import load_credentials as _load_ant
+        if not _load_ant():
+            err_console.print("[fail]Not logged in to Anthropic (Claude Pro/Max). "
+                              "Run `hexis auth anthropic login` first, then re-run init.[/fail]")
+            return 1
+
+    # 2. Resolve model — derive from the live catalog (not a stale hard-code).
+    model = args.model
+    if not model:
+        from apps.tui import model_catalog
+        try:
+            catalog = await model_catalog.fetch_models(provider)
+        except Exception:
+            catalog = []
+        model = model_catalog.recommended_default(provider, catalog)
+        if not model:
+            err_console.print(f"[fail]Could not determine a default model for '{provider}'. Pass --model.[/fail]")
+            return 1
+    api_key_env = "" if provider in _no_key_needed else _PROVIDER_ENV_VARS.get(provider, "")
 
     console.print(make_panel(
-        f"[key]Provider:[/key] {provider}\n"
+        f"[key]Provider:[/key] {persist_provider}\n"
         f"[key]Model:[/key]    {model}",
         title="Non-Interactive Init",
     ))
@@ -353,7 +377,7 @@ async def _run_init_noninteractive(args: argparse.Namespace) -> int:
     try:
         # 7. Save LLM config
         heartbeat_config = {
-            "provider": provider,
+            "provider": persist_provider,
             "model": model,
             "endpoint": "",
             "api_key_env": api_key_env,
@@ -396,10 +420,11 @@ async def _run_init_noninteractive(args: argparse.Namespace) -> int:
             conn,
             dsn=dsn,
             wait_seconds=wait_seconds,
-            provider=provider,
+            provider=persist_provider,
             model=model,
+            non_interactive=True,
         )
-        consented = await _run_consent(conn, llm_config)
+        consented = await _run_consent(conn, llm_config, interactive=False)
         if not consented:
             return 1
 
@@ -481,7 +506,8 @@ def _prompt_int(label: str, *, default: int, min_value: int | None = None) -> in
         return value
 
 
-def _prompt_float(label: str, *, default: float, min_value: float | None = None) -> float:
+def _prompt_float(label: str, *, default: float, min_value: float | None = None,
+                  max_value: float | None = None) -> float:
     while True:
         raw = _prompt(label, default=str(default), required=True)
         try:
@@ -491,6 +517,9 @@ def _prompt_float(label: str, *, default: float, min_value: float | None = None)
             continue
         if min_value is not None and value < min_value:
             err_console.print(f"[fail]Must be >= {min_value}.[/fail]")
+            continue
+        if max_value is not None and value > max_value:
+            err_console.print(f"[fail]Must be <= {max_value}.[/fail]")
             continue
         return value
 
@@ -506,23 +535,14 @@ def _prompt_yes_no(label: str, *, default: bool) -> bool:
         err_console.print("[fail]Enter y/n.[/fail]")
 
 
-def _prompt_choice(label: str, options: list[str], *, default: int = 1) -> int:
-    """Prompt user to pick from a numbered list. Returns 1-based index."""
-    console.print(f"\n[accent]{label}[/accent]\n")
-    for i, option in enumerate(options, 1):
-        marker = "[accent]\u25b8[/accent]" if i == default else " "
-        console.print(f"  {marker} [bold]{i:>2}.[/bold] {option}")
-    console.print()
-    while True:
-        raw = _prompt("Choice", default=str(default))
-        try:
-            choice = int(raw)
-        except ValueError:
-            err_console.print(f"[fail]Enter 1-{len(options)}.[/fail]")
-            continue
-        if 1 <= choice <= len(options):
-            return choice
-        err_console.print(f"[fail]Enter 1-{len(options)}.[/fail]")
+async def _prompt_choice(label: str, options: list[str], *, default: int = 1) -> int:
+    """Arrow-key select from *options*. Returns the 1-based index chosen.
+
+    Async so it runs in the wizard's event loop (questionary's sync API would
+    try to start a nested loop). Ctrl+C raises KeyboardInterrupt → ``main`` exits.
+    """
+    from apps.cli_prompts import select_index
+    return await select_index(label, options, default=default)
 
 
 def _prompt_list(label: str, *, default: list[str] | None = None) -> list[str]:
@@ -543,43 +563,87 @@ async def _configure_llm(conn: Any, *, dsn: str, wait_seconds: int) -> dict[str,
     console.print(f"\n{_step_bar(0)}\n")
     heading("LLM Configuration")
 
-    provider = _prompt(
-        "Provider (openai, openai-codex, anthropic, ollama, chutes, github-copilot, qwen-portal, ...)",
-        default=os.getenv("LLM_PROVIDER", "openai"),
-        required=True,
-    )
-    provider = _normalize_provider_name(provider)
+    from apps.cli_prompts import autocomplete as _ac
+    from apps.cli_prompts import select_value
 
-    default_model = os.getenv("LLM_MODEL") or _DEFAULT_MODELS.get(provider, "gpt-4o")
-    model = _prompt(
-        "Model",
-        default=default_model,
-        required=True,
-    )
-    endpoint = _prompt(
-        "Endpoint (blank for provider default)",
-        default="" if provider in _OAUTH_PROVIDERS else os.getenv("OPENAI_BASE_URL", ""),
-    )
-    api_key_env = _prompt(
-        "API key env var name (e.g. OPENAI_API_KEY)",
-        default=_PROVIDER_ENV_VARS.get(provider, "") or ("OPENAI_API_KEY" if provider in {"openai", "openai_compatible"} else ""),
-    )
+    _PROVIDER_MENU = [
+        ("Claude Pro/Max — Anthropic OAuth subscription (no API key)", "anthropic-oauth"),
+        ("OpenAI Codex — ChatGPT Plus/Pro OAuth (no API key)", "openai-codex"),
+        ("OpenAI — API key", "openai"),
+        ("Anthropic — API key", "anthropic"),
+        ("Grok (xAI) — API key", "grok"),
+        ("Gemini — API key", "gemini"),
+        ("Ollama — local, no key", "ollama"),
+        ("GitHub Copilot — OAuth", "github-copilot"),
+        ("Qwen Portal — OAuth", "qwen-portal"),
+        ("MiniMax Portal — OAuth", "minimax-portal"),
+        ("Other / custom (type it)", "__custom__"),
+    ]
+    # Only honor LLM_PROVIDER if it's actually set — a brand-new user shouldn't
+    # be pre-pointed at a paid API-key path (Bar #5, #6). With nothing set,
+    # highlight the first (featured, zero-key) option instead.
+    _env_provider = os.getenv("LLM_PROVIDER")
+    env_default = _normalize_provider_name(_env_provider) if _env_provider else None
+    provider = await select_value("Provider:", _PROVIDER_MENU, default_value=env_default)
+    if provider == "__custom__":
+        provider = _normalize_provider_name(
+            _prompt("Provider id", default=env_default or "", required=True))
 
-    use_separate_sub = _prompt_yes_no("Use separate subconscious model?", default=False)
+    # Model — the list AND the default both come from the live catalog
+    # (models.dev / local Ollama), the way hermes-agent and openclaw do it. No
+    # stale hard-coded default; any free-typed name is still accepted.
+    from apps.tui import model_catalog
+    catalog: list[str] = []
+    try:
+        console.print("[muted]Fetching available models…[/muted]")
+        catalog = await model_catalog.fetch_models(provider)
+    except Exception:
+        catalog = []
+    default_model = os.getenv("LLM_MODEL") or model_catalog.recommended_default(provider, catalog)
+    if catalog:
+        model = (await _ac("Model (type to filter, or enter your own)", catalog,
+                           default=default_model) or default_model).strip()
+    else:
+        model = _prompt("Model", default=default_model, required=True)
+
+    # OAuth providers need no endpoint / API key. "anthropic-oauth" is a
+    # wizard-only alias: the LLM layer only knows "anthropic" (with no api_key it
+    # auto-resolves the OAuth token at runtime).
+    is_oauth = provider in _OAUTH_PROVIDERS or provider == "anthropic-oauth"
+    persist_provider = "anthropic" if provider == "anthropic-oauth" else provider
+
+    if is_oauth:
+        endpoint = ""
+        api_key_env = ""
+        console.print("[muted]OAuth provider — no endpoint or API key needed.[/muted]")
+        use_separate_sub = False
+    else:
+        endpoint = _prompt(
+            "Endpoint (blank for provider default)",
+            # Only OpenAI-shaped providers should inherit OPENAI_BASE_URL — don't
+            # bleed it into Grok/Gemini/Anthropic (Bar #5).
+            default=os.getenv("OPENAI_BASE_URL", "") if provider in {"openai", "openai_compatible"} else "",
+        )
+        api_key_env = _prompt(
+            "API key env var name (e.g. OPENAI_API_KEY)",
+            default=_PROVIDER_ENV_VARS.get(provider, "") or ("OPENAI_API_KEY" if provider in {"openai", "openai_compatible"} else ""),
+        )
+        use_separate_sub = _prompt_yes_no("Use separate subconscious model?", default=False)
+
     if use_separate_sub:
-        sub_provider = _prompt("Subconscious provider", default=provider, required=True)
+        sub_provider = _prompt("Subconscious provider", default=persist_provider, required=True)
         sub_model = _prompt("Subconscious model", default=model, required=True)
         sub_endpoint = _prompt("Subconscious endpoint", default=endpoint)
         sub_key_env = _prompt("Subconscious API key env var", default=api_key_env)
     else:
-        sub_provider = provider
+        sub_provider = persist_provider
         sub_model = model
         sub_endpoint = endpoint
         sub_key_env = api_key_env
 
     # Save LLM config to DB
     heartbeat_config = {
-        "provider": provider,
+        "provider": persist_provider,
         "model": model,
         "endpoint": endpoint,
         "api_key_env": api_key_env,
@@ -602,26 +666,53 @@ async def _configure_llm(conn: Any, *, dsn: str, wait_seconds: int) -> dict[str,
     await conn.execute("SELECT set_config('llm.chat', $1::jsonb)", json.dumps(heartbeat_config))
     await conn.execute("SELECT set_config('llm.subconscious', $1::jsonb)", json.dumps(subconscious_config))
 
-    console.print(f"\n[ok]\u2714[/ok] Models saved: [bold]{provider}/{model}[/bold]")
+    console.print(f"\n[ok]\u2714[/ok] Models saved: [bold]{persist_provider}/{model}[/bold]")
 
-    # Return resolved config for consent flow
-    return await _load_llm_config_for_consent(
+    # Anthropic OAuth (Claude Pro/Max): log in now so the token is in Hexis's
+    # own store before consent. Always runs (overwrites any existing token).
+    if provider == "anthropic-oauth":
+        console.print("\n[accent]Log in with your Claude Pro/Max subscription:[/accent]")
+        from apps.cli_auth import _anthropic_oauth_login
+        rc = await _anthropic_oauth_login(dsn, wait_seconds)
+        if rc != 0:
+            err_console.print(
+                "[warn]\u26a0[/warn] Login didn't complete. Run "
+                "`hexis auth anthropic login` in a terminal, then re-run `hexis init`."
+            )
+
+    # Resolve credentials for the consent flow (runs OAuth login for the
+    # loader-based OAuth providers; Anthropic is handled just above).
+    resolved = await _load_llm_config_for_consent(
         conn,
         dsn=dsn,
         wait_seconds=wait_seconds,
-        provider=provider,
+        provider=persist_provider,
         model=model,
     )
+
+    # Optional, advisory connectivity check (never blocks \u2014 a bad key surfaces
+    # here with a clear message instead of a confusing failure at consent).
+    if _prompt_yes_no("Test the connection now?", default=True):
+        from core.init_api import test_llm_connection
+        console.print("[muted]Testing\u2026[/muted]")
+        result = await test_llm_connection(resolved)
+        if result["ok"]:
+            console.print(f"[ok]\u2714[/ok] {result['message']}")
+        else:
+            err_console.print(f"[warn]\u26a0[/warn] {result['message']}")
+            console.print("[muted]You can continue anyway; fix it later with `hexis init`.[/muted]")
+
+    return resolved
 
 
 # ---------------------------------------------------------------------------
 # Tier selection
 # ---------------------------------------------------------------------------
 
-def _choose_tier() -> str:
+async def _choose_tier() -> str:
     """Let user pick Express, Character, or Custom."""
     console.print(f"\n{_step_bar(1)}\n")
-    choice = _prompt_choice(
+    choice = await _prompt_choice(
         "Choose your path:",
         [
             "[bold]Express[/bold]      [muted]\u2014 Use sensible defaults, start immediately[/muted]",
@@ -686,7 +777,7 @@ async def _run_character(conn: Any) -> str:
         table.add_row(str(i), summary["name"], voice_preview, summary["values"] or "\u2014")
     console.print(table)
 
-    choice_idx = _prompt_choice("Pick a character:", [get_card_summary(c)["name"] for c in cards], default=1)
+    choice_idx = await _prompt_choice("Pick a character:", [get_card_summary(c)["name"] for c in cards], default=1)
     chosen = cards[choice_idx - 1]
     summary = get_card_summary(chosen)
 
@@ -701,7 +792,7 @@ async def _run_character(conn: Any) -> str:
 
     tweak = _prompt_yes_no("Tweak anything?", default=False)
     if tweak:
-        tweak_choice = _prompt_choice(
+        tweak_choice = await _prompt_choice(
             "Tweak options:",
             [
                 "Name / voice / description",
@@ -780,12 +871,17 @@ async def _run_custom(
                 f"  {trait.capitalize()} (0.0-1.0)",
                 default=default_val,
                 min_value=0.0,
+                max_value=1.0,
             )
 
     personality_desc = pf.get("personality_description", "reflective and exploratory")
 
     if user_name is None:
         user_name = _prompt(f"\nWhat should {agent_name} call you?", default="User")
+
+    # Idempotent re-init: the custom path calls the init_* functions individually
+    # (not the wrapped entry functions), so clear any prior init persona first.
+    await conn.fetchval("SELECT reset_persona()")
 
     # Apply Phase 1
     await conn.fetchval("SELECT init_mode('persona')")
@@ -879,8 +975,13 @@ async def _run_custom(
 # Consent
 # ---------------------------------------------------------------------------
 
-async def _run_consent(conn: Any, llm_config: dict[str, Any]) -> bool:
-    """Run consent flow via LLM. Returns True if consented."""
+async def _run_consent(conn: Any, llm_config: dict[str, Any], *, interactive: bool = True) -> bool:
+    """Run the consent flow. Returns True if the agent should be activated.
+
+    Consent is a signal that Hexis takes the agent seriously — not a lock. If the
+    model doesn't consent, an interactive owner may proceed anyway (it's their AI);
+    non-interactive callers honor the model's answer without prompting.
+    """
     from rich.spinner import Spinner
     from rich.live import Live
     from core.init_api import run_consent_flow
@@ -933,16 +1034,46 @@ async def _run_consent(conn: Any, llm_config: dict[str, Any]) -> bool:
         console.print(make_panel("\n".join(lines), title="Agent Response"))
 
     if decision == "consent":
-        console.print(f"[ok]\u2714 Consent granted[/ok]")
+        console.print("[ok]\u2714 Consent granted[/ok]")
         return True
+
+    # Not consent (declined / abstained / no clear decision). It's the owner's
+    # agent \u2014 honor the "no" by default, but never trap the owner out (Bar #2).
+    if not result.get("decided"):
+        console.print("[warn]The model didn't return a clear consent decision.[/warn]")
+        model_state = "no clear decision"
     elif decision == "decline":
-        console.print(f"[fail]\u2718 Consent declined.[/fail] The agent chose not to initialize.")
-        console.print("[muted]You can re-run `hexis init` to try again.[/muted]")
-        return False
+        console.print("[warn]The model declined consent[/warn] (its reasoning is above).")
+        model_state = "decline"
     else:
-        console.print(f"[warn]\u26a0 Consent abstained.[/warn] No initialization will occur.")
-        console.print("[muted]You can re-run `hexis init` to try again.[/muted]")
+        console.print("[warn]The model abstained[/warn] (its reasoning is above).")
+        model_state = "abstain"
+
+    # Non-interactive (CI/scripts): honor the model's answer, don't prompt.
+    if not interactive:
+        console.print("[muted]Agent not activated. Re-run interactively to override, "
+                      "or try a more capable model.[/muted]")
         return False
+
+    choice = await _prompt_choice(
+        "It's your agent \u2014 how would you like to proceed?",
+        [
+            "Proceed anyway \u2014 activate it (records that you overrode the model)",
+            "Try again \u2014 re-ask the model",
+            "Cancel \u2014 leave the agent inactive for now",
+        ],
+        default=1,
+    )
+    if choice == 1:
+        from core.init_api import record_consent_override
+        await record_consent_override(conn, llm_config, model_decision=model_state)
+        console.print("[ok]\u2714 Activated.[/ok] [muted]The model's response is recorded; "
+                      "you chose to proceed \u2014 it's your AI.[/muted]")
+        return True
+    if choice == 2:
+        return await _run_consent(conn, llm_config)
+    console.print("[muted]Agent left inactive. Re-run `hexis init` any time to try again.[/muted]")
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -965,7 +1096,7 @@ async def _run_init(dsn: str, *, wait_seconds: int) -> int:
         llm_config = await _configure_llm(conn, dsn=dsn, wait_seconds=wait_seconds)
 
         # Choose tier
-        tier = _choose_tier()
+        tier = await _choose_tier()
 
         # Run selected tier
         if tier == "express":
@@ -985,11 +1116,45 @@ async def _run_init(dsn: str, *, wait_seconds: int) -> int:
         profile = json.loads(raw) if isinstance(raw, str) else (raw or {})
         agent_name = profile.get("agent", {}).get("name", "Hexis")
 
-        console.print(f"\n[ok]\u2714[/ok] [bold]{agent_name}[/bold] is ready. Run [accent]hexis chat[/accent] to say hello.")
+        # Recap what's set up.
+        console.print(f"\n[ok]\u2714[/ok] [bold]{agent_name}[/bold] is ready.")
+        console.print(make_panel(
+            f"[key]Model:[/key]  {llm_config.get('provider', '?')} / {llm_config.get('model', '?')}\n"
+            f"[key]Path:[/key]   {tier}\n"
+            f"[key]User:[/key]   {user_name}",
+            title="What's set up",
+        ))
+        console.print("[muted]Change anything later with `hexis init` \u00b7 "
+                      "enable the autonomous heartbeat with `hexis start`.[/muted]")
+        console.print("[muted]Hexis runs on your machine and sends no telemetry.[/muted]")
         return 0
 
     finally:
         await conn.close()
+
+
+def _post_init_handoff() -> int:
+    """After a successful init, offer to jump straight into chat or the web UI.
+
+    Runs in the sync layer (the wizard's event loop has closed), so it starts a
+    fresh loop just for the prompt.
+    """
+    try:
+        choice = asyncio.run(_prompt_choice(
+            "What now?",
+            ["Open chat now", "Open the web dashboard", "Exit"],
+            default=1,
+        ))
+    except (KeyboardInterrupt, Exception):
+        console.print("[muted]Run `hexis chat` to say hello.[/muted]")
+        return 0
+    if choice == 1:
+        from apps import cli_chat
+        return cli_chat.main(["--greet"])
+    if choice == 2:
+        from apps.hexis_cli import main as cli_main
+        return cli_main(["ui"])
+    return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1040,13 +1205,18 @@ def main(argv: list[str] | None = None) -> int:
         dsn = agent_api.db_dsn_from_env()
 
     try:
-        return asyncio.run(_run_init(dsn, wait_seconds=args.wait_seconds))
+        rc = asyncio.run(_run_init(dsn, wait_seconds=args.wait_seconds))
     except KeyboardInterrupt:
         err_console.print("\n[warn]Cancelled.[/warn]")
         return 130
     except Exception as e:
         err_console.print(f"[fail]init failed: {e}[/fail]")
         return 1
+    # Handoff runs in the sync layer (after the event loop closes) so the chat
+    # REPL can start its own loop without nesting asyncio.run.
+    if rc == 0:
+        return _post_init_handoff()
+    return rc
 
 
 if __name__ == "__main__":

--- a/apps/tui/__init__.py
+++ b/apps/tui/__init__.py
@@ -1,7 +1,20 @@
-"""Hexis TUI — Textual terminal interfaces for init and chat."""
+"""Hexis TUI — legacy Textual interfaces (kept, but no longer the default).
+
+The CLI now uses line-based paths (apps/hexis_init.py, apps/cli_chat.py). These
+Textual apps remain importable via ``HexisInitApp`` / ``HexisChatApp`` but are
+imported lazily so that importing sibling helpers (model_catalog, textkit, tips)
+never pulls in Textual.
+"""
 from __future__ import annotations
 
-from apps.tui.init_app import HexisInitApp
-from apps.tui.chat_app import HexisChatApp
-
 __all__ = ["HexisInitApp", "HexisChatApp"]
+
+
+def __getattr__(name: str):
+    if name == "HexisInitApp":
+        from apps.tui.init_app import HexisInitApp
+        return HexisInitApp
+    if name == "HexisChatApp":
+        from apps.tui.chat_app import HexisChatApp
+        return HexisChatApp
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/apps/tui/activity.py
+++ b/apps/tui/activity.py
@@ -1,0 +1,98 @@
+"""Tool-activity model for the chat transcript.
+
+A small, framework-free record of the tool calls in a turn: status derivation
+(running / done / error), a ring-buffered cap so a chatty turn can't flood
+scrollback, an output-preview char cap, and secret/path redaction applied
+*before* anything is handed to a widget.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from apps.tui import textkit
+
+ENTRY_LIMIT = 100          # ring buffer — keep only the most recent N tools
+PREVIEW_LIMIT = 2000       # chars of tool output kept for preview
+
+
+@dataclass
+class ToolEntry:
+    name: str
+    status: str = "running"          # running | done | error
+    duration_ms: int | None = None
+    preview: str = ""
+    error: str = ""
+
+    @property
+    def glyph(self) -> str:
+        return {"running": "●", "done": "✓", "error": "✗"}.get(self.status, "•")
+
+    @property
+    def token(self) -> str:
+        """Palette token name for this entry's status color."""
+        return {"running": "accent", "done": "ok", "error": "danger"}.get(
+            self.status, "dim"
+        )
+
+    def duration_str(self) -> str:
+        if self.duration_ms is None:
+            return ""
+        secs = self.duration_ms / 1000.0
+        return f"{secs:.1f}s" if secs >= 0.1 else f"{self.duration_ms}ms"
+
+
+@dataclass
+class ToolActivity:
+    """The tool calls made within a single assistant turn."""
+
+    entries: list[ToolEntry] = field(default_factory=list)
+
+    def start(self, name: str) -> ToolEntry:
+        entry = ToolEntry(name=name, status="running")
+        self.entries.append(entry)
+        if len(self.entries) > ENTRY_LIMIT:
+            self.entries = self.entries[-ENTRY_LIMIT:]
+        return entry
+
+    def complete(
+        self,
+        name: str,
+        *,
+        success: bool,
+        duration: float | None = None,
+        output: str = "",
+        error: str = "",
+    ) -> ToolEntry:
+        # Match the most recent still-running entry with this name.
+        entry = next(
+            (e for e in reversed(self.entries)
+             if e.name == name and e.status == "running"),
+            None,
+        )
+        if entry is None:
+            entry = self.start(name)
+        entry.status = "done" if success else "error"
+        if duration is not None:
+            entry.duration_ms = int(duration * 1000)
+        if output:
+            entry.preview = textkit.truncate(textkit.redact(output), PREVIEW_LIMIT)
+        if error:
+            entry.error = textkit.truncate(textkit.redact(error), 400)
+        return entry
+
+    @property
+    def has_error(self) -> bool:
+        return any(e.status == "error" for e in self.entries)
+
+    @property
+    def running(self) -> bool:
+        return any(e.status == "running" for e in self.entries)
+
+    def summary(self) -> str:
+        n = len(self.entries)
+        noun = "tool" if n == 1 else "tools"
+        if self.has_error:
+            return f"{n} {noun} · error"
+        if self.running:
+            return f"{n} {noun} · running"
+        return f"{n} {noun}"

--- a/apps/tui/chat_app.py
+++ b/apps/tui/chat_app.py
@@ -1,32 +1,36 @@
-"""Hexis Chat TUI — Textual app for streaming conversations."""
+"""Hexis Chat TUI — Textual app for streaming conversations.
+
+Streams through ``services.agent.stream_agent`` (unchanged backend contract),
+rendering grouped turns with markup-safe text, batched updates, a collapsible
+reasoning block, an inline tool tree, and a progressive-disclosure status bar.
+"""
 from __future__ import annotations
 
-import time
 import uuid
 from typing import Any
 
 from dotenv import load_dotenv
+from rich.style import Style
+from rich.text import Text
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.binding import Binding
 from textual.screen import Screen
 from textual.widgets import Input, Static
 from textual.worker import Worker, WorkerState
 
-from apps.tui.chat_widgets import (
-    ChatInput,
-    ChatLog,
-    ContextSidebar,
-    StreamingMessage,
-)
+from apps.tui.chat_widgets import COMMANDS, Composer, SlashMenu, Transcript
+from apps.tui.design import COLORS, GLYPHS
+from apps.tui.status_bar import StatusBar
 from apps.tui.theme import hexis_theme
 
 
 class ChatScreen(Screen):
-    """Main chat screen with log, input, and optional sidebar."""
+    """Main chat screen: header · transcript · status bar · composer."""
 
     BINDINGS = [
-        ("ctrl+c", "quit_app", "Quit"),
-        ("ctrl+l", "clear_chat", "Clear"),
+        Binding("ctrl+c", "interrupt_or_quit", "Interrupt / Quit", priority=True),
+        Binding("ctrl+l", "clear_chat", "Clear"),
+        Binding("ctrl+t", "toggle_thinking", "Thinking"),
     ]
 
     def __init__(self) -> None:
@@ -34,336 +38,323 @@ class ChatScreen(Screen):
         self._history: list[dict[str, Any]] = []
         self._verbose = False
         self._debug = False
+        self._show_reasoning = True
         self._agent_name = "Hexis"
+        self._mood = ""
         self._streaming = False
-        self._streaming_msg: StreamingMessage | None = None
-        self._status_text = "streaming chat"
-        self._status_started_at: float | None = None
-        self._status_timer: Any = None
-
-    def _format_elapsed(self) -> str:
-        if self._status_started_at is None:
-            return "0s"
-        total = max(0, int(time.monotonic() - self._status_started_at))
-        if total < 60:
-            return f"{total}s"
-        minutes, seconds = divmod(total, 60)
-        return f"{minutes}m {seconds}s"
-
-    def _render_header(self) -> None:
-        status = self._status_text
-        if self._status_started_at is not None:
-            status = f"{status} · {self._format_elapsed()}"
-        header = self.query_one("#chat-header", Static)
-        header.update(
-            f"[bold #d8774f]{self._agent_name}[/bold #d8774f]"
-            f" [#4e463d]\u2014 {status}[/#4e463d]"
-        )
-
-    def _tick_status(self) -> None:
-        if self._status_started_at is not None:
-            self._render_header()
-
-    def _set_header_status(self, status_text: str, *, busy: bool = False) -> None:
-        if busy:
-            if self._status_text != status_text or self._status_started_at is None:
-                self._status_started_at = time.monotonic()
-            if self._status_timer is None:
-                self._status_timer = self.set_interval(1.0, self._tick_status)
-        else:
-            self._status_started_at = None
-            if self._status_timer is not None:
-                self._status_timer.stop()
-                self._status_timer = None
-        self._status_text = status_text
-        self._render_header()
+        self._current_turn: Any = None
+        self._pending_user = ""
+        self._queued: list[str] = []
+        self._tool_count = 0
+        self._flush_timer: Any = None
 
     def compose(self) -> ComposeResult:
-        yield Static("", id="chat-header", classes="chat-header")
-        with Horizontal():
-            with Vertical(id="chat-column"):
-                yield ChatLog(id="chat-log")
-                yield ChatInput(id="chat-input")
-            yield ContextSidebar(id="context-sidebar")
-        yield Static(
-            " /quit  /clear  /recall <q>  /status  /verbose  /tools  /history ",
-            classes="chat-footer",
-        )
+        yield Static("", id="chat-header")
+        yield Transcript(id="transcript")
+        yield StatusBar(id="status-bar")
+        yield Composer()
+        yield SlashMenu(id="slash-menu")
 
     async def on_mount(self) -> None:
         app: HexisChatApp = self.app  # type: ignore[assignment]
         self._agent_name = app.agent_name
-        self._set_header_status("streaming chat")
+        self._mood = app.mood
+        self._render_header()
+        self.query_one(SlashMenu).display = False
+        status = self.query_one(StatusBar)
+        status.update_state(model=app.model_name, mood=self._mood)
+        await self._refresh_energy()
+        self.query_one(Composer).focus()
 
-        self.query_one("#chat-input", ChatInput).focus()
+    def _render_header(self) -> None:
+        header = self.query_one("#chat-header", Static)
+        t = Text()
+        t.append(f"{GLYPHS['logo']} ", style=Style(color=COLORS["accent"]))
+        t.append(self._agent_name, style=Style(color=COLORS["accent"], bold=True))
+        if self._mood:
+            t.append(f"  {self._mood}", style=Style(color=COLORS["dim"]))
+        header.update(t)
 
-    def on_unmount(self) -> None:
-        if self._status_timer is not None:
-            self._status_timer.stop()
-            self._status_timer = None
+    async def _refresh_energy(self) -> None:
+        """Populate the status bar's energy meter from heartbeat_state."""
+        app: HexisChatApp = self.app  # type: ignore[assignment]
+        try:
+            async with app.pool.acquire() as conn:
+                energy = await conn.fetchval(
+                    "SELECT current_energy FROM heartbeat_state WHERE id = 1"
+                )
+                max_energy = await conn.fetchval(
+                    "SELECT get_config_int('heartbeat.max_energy')"
+                )
+            if energy is not None:
+                self.query_one(StatusBar).update_state(
+                    energy=int(energy), max_energy=int(max_energy or 20)
+                )
+        except Exception:
+            pass  # energy meter is ambient; never block chat on it
+
+    # ── input ────────────────────────────────────────────────────────────────
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "composer":
+            return
+        menu = self.query_one(SlashMenu)
+        value = event.value
+        if value.startswith("/") and " " not in value:
+            menu.show(value)
+        else:
+            menu.hide()
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:
-        if event.input.id != "chat-input":
+        if event.input.id != "composer":
             return
-
         text = event.value.strip()
+        composer = self.query_one(Composer)
+        self.query_one(SlashMenu).hide()
         if not text:
             return
 
-        chat_input = self.query_one("#chat-input", ChatInput)
-
         if text.startswith("/"):
-            chat_input.push_history(text)
-            chat_input.value = ""
+            composer.push_history(text)
+            composer.value = ""
             await self._handle_slash(text)
             return
 
+        composer.push_history(text)
+        composer.value = ""
         if self._streaming:
-            # Keep input intact so the user can resubmit after streaming completes.
+            self._queued.append(text)
+            self.query_one(Transcript).write_info(f"queued ({len(self._queued)})")
             return
-
-        chat_input.push_history(text)
-        chat_input.value = ""
         await self._send_message(text)
 
+    # ── slash commands ───────────────────────────────────────────────────────
     async def _handle_slash(self, text: str) -> None:
-        log = self.query_one("#chat-log", ChatLog)
+        tr = self.query_one(Transcript)
         parts = text.split(maxsplit=1)
         cmd = parts[0].lower()
+        arg = parts[1] if len(parts) > 1 else ""
+        app: HexisChatApp = self.app  # type: ignore[assignment]
 
         if cmd in ("/quit", "/exit"):
             self.app.exit(0)
-            return
-
-        if cmd == "/clear":
+        elif cmd == "/clear":
             self._history.clear()
-            # Remove all children from the ChatLog
-            await log.remove_children()
-            log.write_info("Conversation cleared.")
-            return
-
-        if cmd == "/help":
-            log.write_info("Commands:")
-            log.write_info("  /quit, /exit   — Exit chat")
-            log.write_info("  /clear         — Clear conversation")
-            log.write_info("  /recall <q>    — Search memories")
-            log.write_info("  /status        — Show agent status")
-            log.write_info("  /verbose       — Toggle verbose mode")
-            log.write_info("  /debug         — Toggle debug mode")
-            log.write_info("  /tools         — List available tools")
-            log.write_info("  /history       — Show conversation history")
-            return
-
-        if cmd == "/recall":
-            query = parts[1] if len(parts) > 1 else ""
-            if not query:
-                log.write_error("Usage: /recall <query>")
+            await tr.remove_children()
+            tr.write_info("Conversation cleared.")
+        elif cmd == "/help":
+            tr.write_info("Commands:")
+            for c, desc in COMMANDS:
+                tr.write_info(f"  {c:<11} {desc}")
+            tr.write_info("Keys: ctrl+c interrupt · ctrl+l clear · ctrl+t thinking · tab complete")
+        elif cmd == "/thinking":
+            self._show_reasoning = not self._show_reasoning
+            tr.write_info(f"Reasoning display: {'on' if self._show_reasoning else 'off'}")
+        elif cmd == "/debug":
+            self._debug = not self._debug
+            self._verbose = self._debug
+            tr.write_info(f"Debug: {'on' if self._debug else 'off'}")
+        elif cmd == "/recall":
+            if not arg:
+                tr.write_error("Usage: /recall <query>")
                 return
-            app: HexisChatApp = self.app  # type: ignore[assignment]
             try:
                 from core.cognitive_memory_api import CognitiveMemory
                 async with CognitiveMemory.connect(app.dsn) as mem:
-                    result = await mem.recall(query, limit=5)
+                    result = await mem.recall(arg, limit=5)
                 if not result.memories:
-                    log.write_info("No memories found.")
+                    tr.write_info("No memories found.")
                 else:
-                    log.write_recall(result.memories)
+                    tr.write_recall(result.memories)
             except Exception as e:
-                log.write_error(str(e))
-            return
-
-        if cmd == "/status":
-            app: HexisChatApp = self.app  # type: ignore[assignment]
+                tr.write_error(str(e))
+        elif cmd == "/status":
             try:
                 from core.cli_api import status_payload_rich
                 payload = await status_payload_rich(app.dsn)
-                agent = payload.get("agent", {})
-                log.write_info(f"Agent: {agent.get('name', '?')}")
-                log.write_info(f"Mood: {agent.get('mood', '?')}")
-                energy = payload.get("energy", {})
-                log.write_info(f"Energy: {energy.get('current', '?')}/{energy.get('max', '?')}")
+                agent = payload.get("agent", {}) if isinstance(payload.get("agent"), dict) else {}
+                tr.write_info(f"Agent: {agent.get('name', self._agent_name)}")
+                if payload.get("mood"):
+                    tr.write_info(f"Mood: {payload.get('mood')}")
+                energy = payload.get("energy")
+                max_e = payload.get("max_energy")
+                if energy is not None:
+                    tr.write_info(f"Energy: {energy}/{max_e}")
                 consent = payload.get("consent", {})
-                log.write_info(f"Consent: {consent.get('status', '?')}")
+                if isinstance(consent, dict) and consent.get("status"):
+                    tr.write_info(f"Consent: {consent.get('status')}")
             except Exception as e:
-                log.write_error(str(e))
-            return
-
-        if cmd == "/verbose":
-            self._verbose = not self._verbose
-            sidebar = self.query_one("#context-sidebar", ContextSidebar)
-            if self._verbose:
-                sidebar.add_class("visible")
-            else:
-                sidebar.remove_class("visible")
-            log.write_info(f"Verbose mode: {'on' if self._verbose else 'off'}")
-            return
-
-        if cmd == "/debug":
-            self._debug = not self._debug
-            self._verbose = self._verbose or self._debug
-            log.write_info(f"Debug mode: {'on' if self._debug else 'off'} (verbose: {'on' if self._verbose else 'off'})")
-            return
-
-        if cmd == "/tools":
-            app: HexisChatApp = self.app  # type: ignore[assignment]
+                tr.write_error(str(e))
+        elif cmd == "/tools":
             try:
                 from core.tools import ToolContext
                 specs = await app.registry.get_specs(ToolContext.CHAT)
-                log.write_info("Available Tools:")
+                tr.write_info(f"Available tools ({len(specs)}):")
                 for spec in specs:
                     func = spec.get("function", {})
-                    name = func.get("name", "?")
-                    desc = func.get("description", "")[:60]
-                    log.write_info(f"  [#3c6f64]{name}[/#3c6f64] — {desc}")
+                    tr.write_info(f"  {func.get('name', '?')} — "
+                                  f"{(func.get('description') or '')[:60]}")
             except Exception as e:
-                log.write_error(str(e))
-            return
-
-        if cmd == "/history":
+                tr.write_error(str(e))
+        elif cmd == "/history":
             if not self._history:
-                log.write_info("No conversation history yet.")
+                tr.write_info("No conversation history yet.")
             else:
                 for i, msg in enumerate(self._history):
-                    role = msg["role"]
-                    content = msg["content"][:100]
-                    log.write_info(f"  {i} [{role}]: {content}")
-            return
+                    tr.write_info(f"  {i} [{msg['role']}]: {msg['content'][:100]}")
+        else:
+            tr.write_error(f"Unknown command: {cmd}")
+            tr.write_info("Type /help for available commands.")
 
-        log.write_error(f"Unknown command: {cmd}")
-        log.write_info("Type /help for available commands.")
-
+    # ── streaming ──────────────────────────────────────────────────────────────
     async def _send_message(self, text: str) -> None:
-        log = self.query_one("#chat-log", ChatLog)
-        log.write_user(text)
-
+        tr = self.query_one(Transcript)
+        await tr.add_user(text)
+        self._pending_user = text
+        self._tool_count = 0
         self._streaming = True
-        self._set_header_status("waiting", busy=True)
-        self._streaming_msg = log.start_assistant(self._agent_name)
-        self.run_worker(
-            self._stream_response(text),
-            name="chat-stream",
-            exclusive=True,
-        )
+        self._current_turn = await tr.add_assistant(self._agent_name)
+        self._current_turn.show_reasoning(self._show_reasoning)
+        self.query_one(StatusBar).set_busy("thinking")
+        self._flush_timer = self.set_interval(0.1, self._flush)
+        self.run_worker(self._stream_response(text), name="chat-stream", exclusive=True)
 
-    async def _stream_response(self, user_input: str) -> str:
+    async def _flush(self) -> None:
+        if self._current_turn is not None:
+            await self._current_turn.flush()
+            self.query_one(Transcript).scroll_end(animate=False)
+
+    async def _stream_response(self, user_input: str) -> None:
         from core.agent_loop import AgentEvent
-        from core.cognitive_memory_api import CognitiveMemory
         from services.agent import stream_agent
-        from services.chat import _remember_conversation
 
         app: HexisChatApp = self.app  # type: ignore[assignment]
-        log = self.query_one("#chat-log", ChatLog)
-        streaming_msg = self._streaming_msg
-
+        tr = self.query_one(Transcript)
+        status = self.query_one(StatusBar)
+        turn = self._current_turn
         session_id = str(uuid.uuid4())
-        full_text = ""
-        saw_first_token = False
+        saw_token = False
 
-        # Use the unified agent runner (subconscious → memory hydration → conscious loop)
         async for event in stream_agent(
-            app.pool,
-            app.registry,
-            user_message=user_input,
-            mode="chat",
-            history=self._history,
-            session_id=session_id,
-            dsn=app.dsn,
+            app.pool, app.registry,
+            user_message=user_input, mode="chat",
+            history=self._history, session_id=session_id, dsn=app.dsn,
         ):
-            if event.event == AgentEvent.PHASE_CHANGE:
-                phase = event.data.get("phase", "")
-                status = event.data.get("status", "")
+            ev = event.event
+            data = event.data
+            if ev == AgentEvent.PHASE_CHANGE:
+                phase = data.get("phase", "")
+                st = data.get("status", "")
                 if phase == "memory_recall":
-                    if status == "start":
-                        self._set_header_status("recalling memories", busy=True)
-                        log.write_info("Recalling memories...")
-                    else:
-                        self._set_header_status("thinking...", busy=True)
-                        count = event.data.get("count", 0)
-                        log.write_info(f"Recalled {count} memories")
+                    status.set_busy("recalling memories" if st == "start" else "thinking")
+                    if st == "end" and self._verbose:
+                        tr.write_info(f"recalled {data.get('count', 0)} memories")
                 elif phase == "subconscious":
-                    if self._verbose:
-                        if status == "start":
-                            log.write_info("Subconscious appraisal...")
-                        elif status == "end":
-                            log.write_info("Subconscious appraisal complete")
-                    if status == "start":
-                        self._set_header_status("reasoning", busy=True)
-                    elif status == "end":
-                        self._set_header_status("thinking...", busy=True)
-
-            elif event.event == AgentEvent.TEXT_DELTA:
-                text = event.data.get("text", "")
-                if text and streaming_msg:
-                    if not saw_first_token:
-                        saw_first_token = True
-                        self._set_header_status("streaming", busy=True)
-                    full_text += text
-                    streaming_msg.append_text(text)
-
-            elif event.event == AgentEvent.TOOL_START:
-                tool_name = event.data.get("tool_name", "tool")
-                log.write_tool_start(tool_name)
-
-            elif event.event == AgentEvent.TOOL_RESULT:
-                tool_name = event.data.get("tool_name", "tool")
-                success = event.data.get("success", False)
-                duration = event.data.get("duration")
-                error = event.data.get("error", "")
-                log.write_tool_result(tool_name, success, duration, error)
-
-            elif event.event == AgentEvent.ERROR:
-                error_msg = event.data.get("error", "Unknown error")
-                log.write_error(error_msg)
-                self._set_header_status("error")
-
-        # Finalize streaming message
-        if streaming_msg:
-            log.finish_assistant(streaming_msg, full_text)
-
-        # Update history
-        self._history.append({"role": "user", "content": user_input})
-        self._history.append({"role": "assistant", "content": full_text})
-
-        # Memory formation
-        if full_text:
-            try:
-                async with CognitiveMemory.connect(app.dsn) as mem_client:
-                    await _remember_conversation(
-                        mem_client,
-                        user_message=user_input,
-                        assistant_message=full_text,
+                    status.set_busy("reflecting" if st == "start" else "thinking")
+                elif phase in ("plan", "execute", "verify"):
+                    status.set_busy(phase + "ing" if phase != "plan" else "planning")
+            elif ev == AgentEvent.TEXT_DELTA:
+                text = data.get("text", "")
+                if text and turn is not None:
+                    if not saw_token:
+                        saw_token = True
+                        status.set_busy("")  # switch to rotating think-verbs
+                    turn.append_delta(text)
+            elif ev == AgentEvent.TOOL_START:
+                name = data.get("tool_name", "tool")
+                self._tool_count += 1
+                status.update_state(tools=self._tool_count)
+                status.set_busy(f"running {name}")
+                if turn is not None:
+                    await turn.tool_start(name)
+            elif ev == AgentEvent.TOOL_RESULT:
+                if turn is not None:
+                    await turn.tool_result(
+                        data.get("tool_name", "tool"), data.get("success", False),
+                        data.get("duration"), data.get("error", "") or "",
                     )
-            except Exception:
-                pass
+                status.set_busy("")
+            elif ev == AgentEvent.CONTINUATION:
+                tr.write_info("continuing…")
+            elif ev == AgentEvent.ENERGY_EXHAUSTED:
+                tr.write_info("energy exhausted")
+            elif ev == AgentEvent.ERROR:
+                tr.write_error(data.get("error", "Unknown error"))
 
-        self._set_header_status("streaming chat")
-        return full_text
-
-    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+    async def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
         if event.worker.name != "chat-stream":
             return
+        if event.state not in (WorkerState.SUCCESS, WorkerState.ERROR, WorkerState.CANCELLED):
+            return
 
-        if event.state in (WorkerState.SUCCESS, WorkerState.ERROR, WorkerState.CANCELLED):
-            self._streaming = False
-            self._streaming_msg = None
-            if event.state == WorkerState.ERROR:
-                self._set_header_status("error")
-            else:
-                self._set_header_status("streaming chat")
-            self.query_one("#chat-input", ChatInput).focus()
+        if self._flush_timer is not None:
+            self._flush_timer.stop()
+            self._flush_timer = None
 
-            if event.state == WorkerState.ERROR:
-                log = self.query_one("#chat-log", ChatLog)
-                log.write_error(str(event.worker.error))
+        turn = self._current_turn
+        if turn is not None:
+            await turn.finalize()
+        self._streaming = False
+        self._current_turn = None
+        status = self.query_one(StatusBar)
+        status.set_idle()
 
-    def action_quit_app(self) -> None:
-        self.app.exit(0)
+        tr = self.query_one(Transcript)
+        if event.state == WorkerState.ERROR:
+            tr.write_error(str(event.worker.error))
+        elif event.state == WorkerState.CANCELLED:
+            tr.write_info("interrupted")
+
+        if event.state == WorkerState.SUCCESS and turn is not None:
+            final_text = getattr(turn, "_visible", "") or ""
+            self._history.append({"role": "user", "content": self._pending_user})
+            self._history.append({"role": "assistant", "content": final_text})
+            if final_text:
+                self.run_worker(
+                    self._remember(self._pending_user, final_text),
+                    name="chat-remember",
+                )
+
+        await self._refresh_energy()
+        self.query_one(Composer).focus()
+
+        # Drain one queued message.
+        if self._queued and not self._streaming:
+            await self._send_message(self._queued.pop(0))
+
+    async def _remember(self, user_input: str, assistant_text: str) -> None:
+        app: HexisChatApp = self.app  # type: ignore[assignment]
+        try:
+            from core.cognitive_memory_api import CognitiveMemory
+            from services.chat import _remember_conversation
+            async with CognitiveMemory.connect(app.dsn) as mem_client:
+                await _remember_conversation(
+                    mem_client, user_message=user_input, assistant_message=assistant_text
+                )
+        except Exception as e:
+            if self._debug:
+                self.query_one(Transcript).write_info(f"[memory] not stored: {e}")
+
+    # ── actions ────────────────────────────────────────────────────────────────
+    def action_interrupt_or_quit(self) -> None:
+        if self._streaming:
+            for worker in list(self.workers):
+                if worker.name == "chat-stream":
+                    worker.cancel()
+        else:
+            self.app.exit(0)
 
     async def action_clear_chat(self) -> None:
         self._history.clear()
-        log = self.query_one("#chat-log", ChatLog)
-        await log.remove_children()
-        log.write_info("Conversation cleared.")
+        await self.query_one(Transcript).remove_children()
+        self.query_one(Transcript).write_info("Conversation cleared.")
+
+    def action_toggle_thinking(self) -> None:
+        self._show_reasoning = not self._show_reasoning
+        if self._current_turn is not None:
+            self._current_turn.show_reasoning(self._show_reasoning)
+        self.query_one(Transcript).write_info(
+            f"Reasoning display: {'on' if self._show_reasoning else 'off'}"
+        )
 
 
 class HexisChatApp(App):
@@ -379,63 +370,62 @@ class HexisChatApp(App):
         self._argv = argv or []
         self.pool: Any = None
         self.registry: Any = None
-        self.system_prompt: str = ""
-        self.llm_config: dict[str, Any] = {}
         self.agent_name: str = "Hexis"
+        self.model_name: str = ""
+        self.mood: str = ""
         self.dsn: str = ""
+        self._verbose = False
+        self._debug = False
+
+    def get_css_variables(self) -> dict[str, str]:
+        from apps.tui.design import CSS_VARS
+        variables = super().get_css_variables()
+        variables.update(CSS_VARS)
+        return variables
 
     async def on_mount(self) -> None:
         load_dotenv()
         import asyncpg
         from core.agent_api import db_dsn_from_env, get_agent_profile_context
         from core.llm_config import load_llm_config
-        from core.tools import ToolContext, create_default_registry
-        from services.chat import _build_system_prompt
+        from core.tools import create_default_registry
 
-        # Parse args
         dsn = None
-        verbose = False
-        debug = False
         i = 0
         while i < len(self._argv):
-            if self._argv[i] == "--dsn" and i + 1 < len(self._argv):
+            a = self._argv[i]
+            if a == "--dsn" and i + 1 < len(self._argv):
                 dsn = self._argv[i + 1]
                 i += 2
-            elif self._argv[i] in ("-v", "--verbose"):
-                verbose = True
+            elif a in ("-v", "--verbose"):
+                self._verbose = True
                 i += 1
-            elif self._argv[i] in ("-d", "--debug"):
-                debug = True
-                verbose = True
+            elif a in ("-d", "--debug"):
+                self._debug = True
+                self._verbose = True
                 i += 1
             else:
                 i += 1
 
         self.dsn = dsn or db_dsn_from_env()
-
         try:
             self.pool = await asyncpg.create_pool(self.dsn, min_size=2, max_size=5)
-
             async with self.pool.acquire() as conn:
-                self.llm_config = await load_llm_config(conn, "llm.chat", fallback_key="llm")
-
+                llm_config = await load_llm_config(conn, "llm.chat", fallback_key="llm")
+            self.model_name = llm_config.get("model", "") if isinstance(llm_config, dict) else ""
             self.registry = create_default_registry(self.pool)
             agent_profile = await get_agent_profile_context(self.dsn)
-            self.system_prompt = await _build_system_prompt(agent_profile, self.registry)
-
             if isinstance(agent_profile, dict):
                 self.agent_name = agent_profile.get("name", "Hexis")
-
+                self.mood = agent_profile.get("mood", "") or ""
         except Exception as e:
             from apps.tui.dialogs import ErrorDialog
             await self.push_screen(ErrorDialog("Connection Error", str(e)))
             return
 
         screen = ChatScreen()
-        if verbose:
-            screen._verbose = True
-        if debug:
-            screen._debug = True
+        screen._verbose = self._verbose
+        screen._debug = self._debug
         await self.push_screen(screen)
 
     async def on_unmount(self) -> None:

--- a/apps/tui/chat_app.py
+++ b/apps/tui/chat_app.py
@@ -22,6 +22,7 @@ from apps.tui.chat_widgets import COMMANDS, Composer, SlashMenu, Transcript
 from apps.tui.design import COLORS, GLYPHS
 from apps.tui.status_bar import StatusBar
 from apps.tui.theme import hexis_theme
+from apps.tui.tips import mark_seen, random_tip, seen
 
 
 class ChatScreen(Screen):
@@ -31,7 +32,22 @@ class ChatScreen(Screen):
         Binding("ctrl+c", "interrupt_or_quit", "Interrupt / Quit", priority=True),
         Binding("ctrl+l", "clear_chat", "Clear"),
         Binding("ctrl+t", "toggle_thinking", "Thinking"),
+        # Keyboard scrolling (mouse wheel is off so the terminal owns the mouse
+        # for text selection / copy).
+        Binding("pageup", "scroll_transcript('page_up')", "Scroll up", show=False),
+        Binding("pagedown", "scroll_transcript('page_down')", "Scroll down", show=False),
+        Binding("ctrl+home", "scroll_transcript('home')", "Top", show=False),
+        Binding("ctrl+end", "scroll_transcript('end')", "Bottom", show=False),
     ]
+
+    def action_scroll_transcript(self, how: str) -> None:
+        tr = self.query_one(Transcript)
+        {
+            "page_up": tr.scroll_page_up,
+            "page_down": tr.scroll_page_down,
+            "home": tr.scroll_home,
+            "end": tr.scroll_end,
+        }.get(how, lambda: None)()
 
     def __init__(self) -> None:
         super().__init__()
@@ -47,6 +63,7 @@ class ChatScreen(Screen):
         self._queued: list[str] = []
         self._tool_count = 0
         self._flush_timer: Any = None
+        self._greet = False
 
     def compose(self) -> ComposeResult:
         yield Static("", id="chat-header")
@@ -63,7 +80,31 @@ class ChatScreen(Screen):
         self.query_one(SlashMenu).display = False
         status = self.query_one(StatusBar)
         status.update_state(model=app.model_name, mood=self._mood)
+        self.query_one(Transcript).write_info(
+            "Keyboard-only — type to chat, / for commands, PageUp/PageDown to "
+            "scroll. Drag with the mouse to select & copy text."
+        )
+        # First-ever open: a one-time contextual hint (show-once).
+        if not seen("chat.opened"):
+            mark_seen("chat.opened")
+            self.query_one(Transcript).write_info(
+                "First time here — Ctrl+C interrupts a reply, Ctrl+T toggles the "
+                "agent's thinking, /help lists everything."
+            )
+        self.query_one(Transcript).write_info(random_tip())
         await self._refresh_energy()
+        # First-run: seed a wake-up turn so the agent greets and (with consent,
+        # no external lookups) offers to learn who you are.
+        if self._greet:
+            self.run_worker(self._seed_greet(), name="greet", exit_on_error=False)
+
+    async def _seed_greet(self) -> None:
+        await self._send_message(
+            "Hi — this is the first time we're talking. Please introduce yourself "
+            "briefly, and if you'd like, feel free to ask a little about me — only "
+            "what I choose to share, and without looking anything up unless I say "
+            "it's okay."
+        )
         self.query_one(Composer).focus()
 
     def _render_header(self) -> None:
@@ -216,7 +257,10 @@ class ChatScreen(Screen):
         self._current_turn.show_reasoning(self._show_reasoning)
         self.query_one(StatusBar).set_busy("thinking")
         self._flush_timer = self.set_interval(0.1, self._flush)
-        self.run_worker(self._stream_response(text), name="chat-stream", exclusive=True)
+        # exit_on_error=False → an LLM/stream failure shows as an error line
+        # instead of crashing the chat app (on_worker_state_changed handles it).
+        self.run_worker(self._stream_response(text), name="chat-stream",
+                        exclusive=True, exit_on_error=False)
 
     async def _flush(self) -> None:
         if self._current_turn is not None:
@@ -311,7 +355,7 @@ class ChatScreen(Screen):
             if final_text:
                 self.run_worker(
                     self._remember(self._pending_user, final_text),
-                    name="chat-remember",
+                    name="chat-remember", exit_on_error=False,
                 )
 
         await self._refresh_energy()
@@ -376,12 +420,23 @@ class HexisChatApp(App):
         self.dsn: str = ""
         self._verbose = False
         self._debug = False
+        self._greet = False  # --greet: seed a first "wake up" turn on first run
+        # Set to "init" when a first-run chat should hand off to setup.
+        self.next_action: str | None = None
 
     def get_css_variables(self) -> dict[str, str]:
         from apps.tui.design import CSS_VARS
         variables = super().get_css_variables()
         variables.update(CSS_VARS)
         return variables
+
+    def run(self, **kwargs):
+        # Keyboard-only by default: don't capture the mouse, so the terminal's
+        # native click-drag text selection / copy keeps working. Set
+        # HEXIS_TUI_MOUSE=1 to re-enable mouse interaction.
+        import os
+        kwargs.setdefault("mouse", os.getenv("HEXIS_TUI_MOUSE", "") == "1")
+        return super().run(**kwargs)
 
     async def on_mount(self) -> None:
         load_dotenv()
@@ -404,13 +459,21 @@ class HexisChatApp(App):
                 self._debug = True
                 self._verbose = True
                 i += 1
+            elif a == "--greet":
+                self._greet = True
+                i += 1
             else:
                 i += 1
 
         self.dsn = dsn or db_dsn_from_env()
+        configured = True
         try:
             self.pool = await asyncpg.create_pool(self.dsn, min_size=2, max_size=5)
             async with self.pool.acquire() as conn:
+                try:
+                    configured = bool(await conn.fetchval("SELECT is_agent_configured()"))
+                except Exception:
+                    configured = True  # never block chat on this probe
                 llm_config = await load_llm_config(conn, "llm.chat", fallback_key="llm")
             self.model_name = llm_config.get("model", "") if isinstance(llm_config, dict) else ""
             self.registry = create_default_registry(self.pool)
@@ -423,9 +486,29 @@ class HexisChatApp(App):
             await self.push_screen(ErrorDialog("Connection Error", str(e)))
             return
 
+        # First-run detection: an empty chat on an unconfigured agent just fails
+        # at the first message. Offer setup instead.
+        if not configured:
+            from apps.tui.dialogs import ConfirmDialog
+
+            def _decide(run_init: bool | None) -> None:
+                if run_init:
+                    self.next_action = "init"
+                self.exit(0)
+
+            await self.push_screen(
+                ConfirmDialog(
+                    "Not set up yet",
+                    "No agent is configured. Run setup (hexis init) now?",
+                ),
+                _decide,
+            )
+            return
+
         screen = ChatScreen()
         screen._verbose = self._verbose
         screen._debug = self._debug
+        screen._greet = self._greet
         await self.push_screen(screen)
 
     async def on_unmount(self) -> None:

--- a/apps/tui/chat_widgets.py
+++ b/apps/tui/chat_widgets.py
@@ -1,230 +1,340 @@
-"""Chat widgets for the Hexis TUI."""
+"""Chat widgets for the Hexis TUI.
+
+Design goals (vs. the old implementation):
+  * grouped, role-aligned turns; one label per turn
+  * markup-safe rendering — model text goes through Rich ``Text``, never a
+    markup f-string, so a stray ``[`` can't corrupt output or raise
+  * batched streaming (update on a timer, not per token) + a blinking caret
+  * finished answers render as Markdown (headings / code / lists)
+  * a dim, collapsible reasoning block fed by the scaffolding strip
+  * a compact inline tool tree with status glyphs + duration
+"""
 from __future__ import annotations
 
 from typing import Any
 
-from textual.app import ComposeResult
+from rich.style import Style
+from rich.text import Text
 from textual.containers import Vertical, VerticalScroll
-from textual.message import Message
-from textual.reactive import reactive
-from textual.widget import Widget
-from textual.widgets import Input, RichLog, Static
+from textual.widgets import Collapsible, Input, Markdown, OptionList, Static
+from textual.widgets.option_list import Option
+
+from apps.tui import textkit
+from apps.tui.activity import ToolActivity
+from apps.tui.design import COLORS, GLYPHS
+
+_TEXT = Style(color=COLORS["text"])
+_DIM = Style(color=COLORS["dim"])
+_MUTED = Style(color=COLORS["muted"])
 
 
-# ── Messages ─────────────────────────────────────────────────────────────────
+# ── Streaming body ───────────────────────────────────────────────────────────
 
-class StreamChunk(Message):
-    """A chunk of streamed text from the agent."""
+class StreamingBlock(Static):
+    """Live assistant text during streaming (plain Rich Text + caret)."""
 
-    def __init__(self, text: str) -> None:
-        super().__init__()
-        self.text = text
+    def __init__(self) -> None:
+        super().__init__("", classes="msg-body")
 
-
-class StreamDone(Message):
-    """Signal that streaming is complete for the current turn."""
-
-    def __init__(self, full_text: str) -> None:
-        super().__init__()
-        self.full_text = full_text
+    def set_text(self, text: str, *, caret: bool = True) -> None:
+        t = Text(text, style=_TEXT, no_wrap=False)
+        if caret:
+            t.append(GLYPHS["caret"], style=Style(color=COLORS["accent"]))
+        self.update(t)
 
 
-class ToolStarted(Message):
-    """A tool call has started."""
+# ── Reasoning (downplayed, collapsible) ──────────────────────────────────────
 
-    def __init__(self, tool_name: str, arguments: dict[str, Any]) -> None:
-        super().__init__()
-        self.tool_name = tool_name
-        self.arguments = arguments
+class ReasoningBlock(Collapsible):
+    """Dim, dashed, collapsed-by-default block holding captured <think> text."""
 
-
-class ToolCompleted(Message):
-    """A tool call has completed."""
-
-    def __init__(
-        self,
-        tool_name: str,
-        success: bool,
-        duration: float | None = None,
-        output: str = "",
-        error: str = "",
-    ) -> None:
-        super().__init__()
-        self.tool_name = tool_name
-        self.success = success
-        self.duration = duration
-        self.output = output
-        self.error = error
-
-
-class ChatError(Message):
-    """An error occurred during streaming."""
-
-    def __init__(self, error: str) -> None:
-        super().__init__()
-        self.error = error
-
-
-# ── StreamingMessage ─────────────────────────────────────────────────────────
-
-class StreamingMessage(Static):
-    """A Static widget that updates in-place as streaming text arrives."""
-
-    text: reactive[str] = reactive("")
-    done: reactive[bool] = reactive(False)
-
-    def __init__(self, agent_name: str, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-        self._agent_name = agent_name
-
-    def render(self) -> str:
-        cursor = "" if self.done else "\u2588"
-        if self.text:
-            return f"[bold #3c6f64]{self._agent_name}:[/bold #3c6f64] {self.text}{cursor}"
-        return f"[bold #3c6f64]{self._agent_name}:[/bold #3c6f64] {cursor}"
-
-    def append_text(self, chunk: str) -> None:
-        self.text += chunk
+    def __init__(self) -> None:
+        self._body = Static("")
+        super().__init__(self._body, title="thinking", collapsed=True,
+                         classes="reasoning")
 
     def set_text(self, text: str) -> None:
-        self.text = text
-
-    def finalize(self, final_text: str | None = None) -> str:
-        """Mark streaming complete and optionally replace content."""
-        if final_text is not None:
-            self.text = final_text
-        self.done = True
-        return self.text
+        self._body.update(Text(text, style=_DIM))
 
 
-# ── ChatLog ──────────────────────────────────────────────────────────────────
+# ── Tool tree (compact, inline) ──────────────────────────────────────────────
 
-class ChatLog(VerticalScroll):
-    """Scrollable chat log that composes Static widgets for each message."""
+class ToolTree(Static):
+    """Box-drawing list of the turn's tool calls with status + duration."""
 
-    def write_user(self, text: str) -> None:
-        self.mount(Static(f"[bold #d8774f]you:[/bold #d8774f] {text}", classes="msg-user"))
+    def __init__(self) -> None:
+        super().__init__("", classes="tool-line")
+
+    def render_activity(self, activity: ToolActivity) -> None:
+        out = Text()
+        n = len(activity.entries)
+        for i, e in enumerate(activity.entries):
+            connector = GLYPHS["leaf"] if i == n - 1 else GLYPHS["branch"]
+            out.append(f"{connector} ", style=_MUTED)
+            out.append(f"{e.glyph} ", style=Style(color=COLORS[e.token]))
+            out.append(e.name, style=_TEXT)
+            dur = e.duration_str()
+            if dur:
+                out.append(f"  {dur}", style=_DIM)
+            if e.status == "error" and e.error:
+                out.append("\n")
+                out.append(f"   {textkit.truncate(e.error, 200)}",
+                           style=Style(color=COLORS["danger"]))
+            if i != n - 1:
+                out.append("\n")
+        self.update(out)
+
+
+# ── Turns ────────────────────────────────────────────────────────────────────
+
+class UserTurn(Vertical):
+    def __init__(self, text: str) -> None:
+        super().__init__(classes="turn turn-user")
+        self._text = text
+
+    def compose(self):
+        yield Static(Text("you", style=Style(color=COLORS["accent"], bold=True)),
+                     classes="role-label role-user")
+        yield Static(Text(self._text, style=_TEXT), classes="msg-body")
+
+
+class AssistantTurn(Vertical):
+    """Streams text, captures reasoning, and tracks tool activity for one turn."""
+
+    def __init__(self, agent_name: str) -> None:
+        super().__init__(classes="turn turn-assistant")
+        self._agent = agent_name
+        self._raw = ""
+        self._visible = ""
+        self._reasoning = ""
+        self._activity = ToolActivity()
+        self._stream: StreamingBlock | None = None
+        self._reasoning_block: ReasoningBlock | None = None
+        self._tool_tree: ToolTree | None = None
+        self._caret_on = True
+        self._done = False
+
+    def compose(self):
+        yield Static(Text(self._agent, style=Style(color=COLORS["teal"], bold=True)),
+                     classes="role-label role-assistant")
+        self._stream = StreamingBlock()
+        yield self._stream
+
+    # incoming stream ---------------------------------------------------------
+    def append_delta(self, raw: str) -> None:
+        self._raw += raw
+
+    async def flush(self) -> None:
+        """Recompute visible/reasoning from the raw buffer and repaint."""
+        if self._done:
+            return
+        visible, reasoning = textkit.strip_scaffolding(self._raw)
+        self._visible = visible
+        self._caret_on = not self._caret_on
+        if self._stream is not None:
+            self._stream.set_text(visible, caret=self._caret_on)
+        if reasoning and reasoning != self._reasoning:
+            self._reasoning = reasoning
+            await self._ensure_reasoning()
+            self._reasoning_block.set_text(reasoning)
+
+    async def _ensure_reasoning(self) -> None:
+        if self._reasoning_block is None:
+            self._reasoning_block = ReasoningBlock()
+            await self.mount(self._reasoning_block)
+
+    # tools -------------------------------------------------------------------
+    async def tool_start(self, name: str) -> None:
+        self._activity.start(name)
+        await self._ensure_tree()
+        self._tool_tree.render_activity(self._activity)
+
+    async def tool_result(self, name: str, success: bool,
+                          duration: float | None, error: str) -> None:
+        self._activity.complete(name, success=success, duration=duration, error=error)
+        await self._ensure_tree()
+        self._tool_tree.render_activity(self._activity)
+
+    async def _ensure_tree(self) -> None:
+        if self._tool_tree is None:
+            self._tool_tree = ToolTree()
+            await self.mount(self._tool_tree)
+
+    # finalize ----------------------------------------------------------------
+    async def finalize(self) -> None:
+        self._done = True
+        visible, reasoning = textkit.strip_scaffolding(self._raw)
+        self._visible = visible
+        if reasoning:
+            await self._ensure_reasoning()
+            self._reasoning_block.set_text(reasoning)
+        # Swap the streaming Static for a Markdown render of the final text.
+        if self._stream is not None:
+            if visible.strip():
+                md = Markdown(visible)
+                md.add_class("msg-body")
+                await self.mount(md, after=self._stream)
+            await self._stream.remove()
+            self._stream = None
+
+    def show_reasoning(self, show: bool) -> None:
+        if self._reasoning_block is not None:
+            self._reasoning_block.collapsed = not show
+
+
+# ── Transcript ───────────────────────────────────────────────────────────────
+
+class Transcript(VerticalScroll):
+    """Scrollable list of turns and inline notices."""
+
+    async def add_user(self, text: str) -> None:
+        await self.mount(UserTurn(text))
         self.scroll_end(animate=False)
 
-    def start_assistant(self, agent_name: str) -> StreamingMessage:
-        msg = StreamingMessage(agent_name, classes="msg-assistant")
-        self.mount(msg)
+    async def add_assistant(self, agent_name: str) -> AssistantTurn:
+        turn = AssistantTurn(agent_name)
+        await self.mount(turn)
         self.scroll_end(animate=False)
-        return msg
-
-    def finish_assistant(
-        self,
-        streaming_msg: StreamingMessage,
-        final_text: str | None = None,
-    ) -> None:
-        streaming_msg.finalize(final_text)
-        self.scroll_end(animate=False)
-
-    def write_tool_start(self, tool_name: str) -> None:
-        self.mount(Static(
-            f"  [italic #4e463d]{tool_name}...[/italic #4e463d]",
-            classes="msg-tool",
-        ))
-        self.scroll_end(animate=False)
-
-    def write_tool_result(
-        self,
-        tool_name: str,
-        success: bool,
-        duration: float | None = None,
-        error: str = "",
-    ) -> None:
-        dur = f" [{duration:.1f}s]" if isinstance(duration, (int, float)) else ""
-        if success:
-            self.mount(Static(
-                f"  [italic #4e463d]{tool_name}[/italic #4e463d] [green]done[/green][dim]{dur}[/dim]",
-                classes="msg-tool",
-            ))
-        else:
-            err_msg = f" {error[:80]}" if error else ""
-            self.mount(Static(
-                f"  [italic #4e463d]{tool_name}[/italic #4e463d] [red]failed[/red][dim]{dur}[/dim] [#4e463d]{err_msg}[/#4e463d]",
-                classes="msg-tool",
-            ))
-        self.scroll_end(animate=False)
-
-    def write_error(self, error: str) -> None:
-        self.mount(Static(f"[bold red]Error: {error}[/bold red]", classes="msg-error"))
-        self.scroll_end(animate=False)
+        return turn
 
     def write_info(self, text: str) -> None:
-        self.mount(Static(f"[#4e463d]{text}[/#4e463d]"))
+        self.mount(Static(Text(text, style=_DIM), classes="msg-info"))
+        self.scroll_end(animate=False)
+
+    def write_error(self, text: str) -> None:
+        self.mount(Static(Text(f"{GLYPHS['err']} {text}",
+                               style=Style(color=COLORS["danger"], bold=True)),
+                          classes="msg-error"))
         self.scroll_end(animate=False)
 
     def write_recall(self, memories: list[Any]) -> None:
         for m in memories:
-            content = m.content[:100] + "..." if len(m.content) > 100 else m.content
-            self.mount(Static(
-                f"  [#3c6f64]{m.type}[/#3c6f64] {content} [#4e463d](sim: {m.similarity:.2f})[/#4e463d]"
-            ))
+            line = Text()
+            line.append(f"{GLYPHS['bullet']} ", style=_MUTED)
+            line.append(f"{m.type} ", style=Style(color=COLORS["teal"]))
+            line.append(textkit.truncate(m.content, 110), style=_TEXT)
+            sim = getattr(m, "similarity", None)
+            if isinstance(sim, (int, float)):
+                line.append(f"  ({sim:.2f})", style=_DIM)
+            self.mount(Static(line, classes="msg-info"))
         self.scroll_end(animate=False)
 
 
-# ── ChatInput ────────────────────────────────────────────────────────────────
+# ── Slash-command menu ───────────────────────────────────────────────────────
 
-class ChatInput(Input):
-    """Chat input with command history via Up/Down arrows."""
+COMMANDS: list[tuple[str, str]] = [
+    ("/help", "show commands"),
+    ("/recall", "search memories — /recall <query>"),
+    ("/status", "agent status"),
+    ("/tools", "list available tools"),
+    ("/thinking", "toggle reasoning display"),
+    ("/history", "show conversation history"),
+    ("/clear", "clear the conversation"),
+    ("/debug", "toggle debug logging"),
+    ("/quit", "exit chat"),
+]
+
+
+class SlashMenu(OptionList):
+    """Autocomplete popup shown while the composer holds a bare '/command'."""
+
+    def show(self, prefix: str) -> None:
+        self.clear_options()
+        matches = [(c, d) for c, d in COMMANDS if c.startswith(prefix.lower())]
+        for cmd, desc in matches:
+            label = Text.assemble(
+                (cmd, Style(color=COLORS["accent"], bold=True)),
+                ("  " + desc, _DIM),
+            )
+            self.add_option(Option(label, id=cmd))
+        self.display = bool(matches)
+        if matches:
+            self.highlighted = 0
+
+    def hide(self) -> None:
+        self.display = False
+
+    def current(self) -> str | None:
+        if not self.display or self.highlighted is None:
+            return None
+        try:
+            return self.get_option_at_index(self.highlighted).id
+        except Exception:
+            return None
+
+    def move(self, delta: int) -> None:
+        if not self.option_count:
+            return
+        cur = self.highlighted or 0
+        self.highlighted = (cur + delta) % self.option_count
+
+
+# ── Composer ─────────────────────────────────────────────────────────────────
+
+class Composer(Input):
+    """Message input with slash autocomplete and command history."""
 
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(placeholder="Type a message... (/help for commands)", **kwargs)
+        super().__init__(placeholder=textkit.PLACEHOLDERS[0], id="composer", **kwargs)
         self._history: list[str] = []
         self._history_idx: int = -1
-        self._saved_input: str = ""
+        self._saved: str = ""
+
+    def _menu(self) -> SlashMenu | None:
+        try:
+            return self.screen.query_one(SlashMenu)
+        except Exception:
+            return None
 
     def on_key(self, event: Any) -> None:
-        if event.key == "up":
-            if self._history:
-                if self._history_idx == -1:
-                    self._saved_input = self.value
-                    self._history_idx = len(self._history) - 1
-                elif self._history_idx > 0:
-                    self._history_idx -= 1
+        menu = self._menu()
+        menu_open = bool(menu and menu.display)
+
+        if event.key == "escape" and menu_open:
+            menu.hide()
+            event.prevent_default()
+            return
+
+        if event.key == "tab" and menu_open:
+            choice = menu.current()
+            if choice:
+                self.value = choice + " "
+                self.cursor_position = len(self.value)
+                menu.hide()
+            event.prevent_default()
+            return
+
+        if event.key in ("up", "down"):
+            if menu_open:
+                menu.move(-1 if event.key == "up" else 1)
+                event.prevent_default()
+                return
+            self._walk_history(event.key)
+            event.prevent_default()
+
+    def _walk_history(self, key: str) -> None:
+        if key == "up":
+            if not self._history:
+                return
+            if self._history_idx == -1:
+                self._saved = self.value
+                self._history_idx = len(self._history) - 1
+            elif self._history_idx > 0:
+                self._history_idx -= 1
+            self.value = self._history[self._history_idx]
+        else:  # down
+            if self._history_idx < 0:
+                return
+            if self._history_idx < len(self._history) - 1:
+                self._history_idx += 1
                 self.value = self._history[self._history_idx]
-                self.cursor_position = len(self.value)
-            event.prevent_default()
-        elif event.key == "down":
-            if self._history_idx >= 0:
-                if self._history_idx < len(self._history) - 1:
-                    self._history_idx += 1
-                    self.value = self._history[self._history_idx]
-                else:
-                    self._history_idx = -1
-                    self.value = self._saved_input
-                self.cursor_position = len(self.value)
-            event.prevent_default()
+            else:
+                self._history_idx = -1
+                self.value = self._saved
+        self.cursor_position = len(self.value)
 
     def push_history(self, text: str) -> None:
         if text and (not self._history or self._history[-1] != text):
             self._history.append(text)
         self._history_idx = -1
-        self._saved_input = ""
-
-
-# ── ContextSidebar ───────────────────────────────────────────────────────────
-
-class ContextSidebar(Widget):
-    """Optional sidebar showing hydrated context."""
-
-    def compose(self) -> ComposeResult:
-        yield RichLog(id="context-log", wrap=True, markup=True)
-
-    def update_context(self, context_text: str) -> None:
-        log = self.query_one("#context-log", RichLog)
-        log.clear()
-        if context_text:
-            log.write("[bold #3c6f64]Hydrated Context[/bold #3c6f64]")
-            log.write("")
-            log.write(context_text)
-        else:
-            log.write("[#4e463d]No memory context[/#4e463d]")
-
-    def toggle(self) -> None:
-        if self.has_class("visible"):
-            self.remove_class("visible")
-        else:
-            self.add_class("visible")
+        self._saved = ""

--- a/apps/tui/design.py
+++ b/apps/tui/design.py
@@ -1,0 +1,124 @@
+"""Hexis TUI design tokens — the single source of truth for color.
+
+Two consumers:
+  * `hexis.tcss` uses the Textual theme variables registered here (``$primary``,
+    ``$secondary``, ``$muted``, ``$dim`` …) so the stylesheet never hard-codes hex.
+  * Python widgets that render Rich renderables import ``COLORS`` / the small
+    ``style`` helpers below — never f-string markup on model-supplied text.
+
+Keep the burnt-orange + teal identity; everything else is derived from it.
+"""
+from __future__ import annotations
+
+from rich.style import Style
+from rich.text import Text
+from textual.theme import Theme
+
+# ── Palette ──────────────────────────────────────────────────────────────────
+# Identity is `accent` (burnt orange) + `teal`. Accent is used with restraint:
+# the composer prompt, the active/running affordance, headings — not everywhere.
+
+COLORS: dict[str, str] = {
+    # identity
+    "accent": "#d8774f",         # burnt orange — headings, user, running spinner
+    "accent_strong": "#b45835",  # darker orange — hover / pressed
+    "teal": "#3c6f64",           # secondary — labels, assistant name, links
+    "teal_dim": "#2d544c",
+    # depth (layered shades stand in for openclaw's glass)
+    "bg": "#1a1a1a",
+    "surface": "#242424",
+    "elevated": "#2e2a26",
+    # text hierarchy
+    "text": "#e0d8d0",           # body
+    "strong": "#f4ece2",         # headings / emphasis
+    "dim": "#9a8f80",            # readable secondary / metadata
+    "muted": "#4e463d",          # borders, rules, very-dim (NOT body text)
+    # semantic
+    "ok": "#5cba7d",
+    "warn": "#d9a441",
+    "danger": "#d4574e",
+    "info": "#5a8bbf",
+}
+
+
+def c(name: str) -> str:
+    """Return a palette hex by token name (raises on typo — fail loud)."""
+    return COLORS[name]
+
+
+# Extra CSS variables beyond Textual's built-ins ($primary/$secondary/$surface/
+# $panel/$success/$warning/$error/…). Injected via App.get_css_variables so they
+# resolve even on the *first* stylesheet parse (before the theme is activated).
+CSS_VARS: dict[str, str] = {
+    "muted": COLORS["muted"],
+    "dim": COLORS["dim"],
+    "elevated": COLORS["elevated"],
+    "strong": COLORS["strong"],
+    "info": COLORS["info"],
+    "teal-dim": COLORS["teal_dim"],
+    "accent-strong": COLORS["accent_strong"],
+}
+
+
+# ── Rich helpers (markup-safe) ───────────────────────────────────────────────
+# Always build Text with explicit styles; never interpolate model text into a
+# markup string (a stray "[" would corrupt or raise MarkupError).
+
+def styled(text: str, token: str, *, bold: bool = False, italic: bool = False,
+           dim: bool = False) -> Text:
+    """A Rich ``Text`` in a palette color, from *plain* text (no markup parsed)."""
+    return Text(text, style=Style(color=COLORS.get(token, token), bold=bold,
+                                  italic=italic, dim=dim))
+
+
+def label(text: str, token: str = "teal") -> Text:
+    """A bold field/section label."""
+    return styled(text, token, bold=True)
+
+
+# ── Glyphs ───────────────────────────────────────────────────────────────────
+
+GLYPHS = {
+    "prompt": "❯",       # ❯  composer prompt
+    "run": "●",          # ●  tool running
+    "ok": "✓",           # ✓  done
+    "err": "✗",          # ✗  failed
+    "caret": "▌",        # ▌  streaming caret
+    "bullet": "•",       # •
+    "sep": "│",          # │  status-bar separator
+    "rail": "┃",         # ┃
+    "branch": "├─", # ├─
+    "leaf": "└─",   # └─
+    "chev_open": "▾",    # ▾
+    "chev_closed": "▸",  # ▸
+    "energy": "⚡",       # ⚡
+    "logo": "⬡",         # ⬡  hexagon wordmark mark
+}
+
+
+# ── Textual theme ────────────────────────────────────────────────────────────
+# Built-ins we lean on in CSS: $primary (accent), $secondary (teal),
+# $accent (accent_strong), $foreground, $background, $surface, $panel,
+# $success/$warning/$error. Extra tokens registered as custom variables below.
+
+hexis_theme = Theme(
+    name="hexis",
+    primary=COLORS["accent"],
+    secondary=COLORS["teal"],
+    accent=COLORS["accent_strong"],
+    foreground=COLORS["text"],
+    background=COLORS["bg"],
+    surface=COLORS["surface"],
+    panel=COLORS["elevated"],
+    success=COLORS["ok"],
+    warning=COLORS["warn"],
+    error=COLORS["danger"],
+    dark=True,
+    variables={
+        **CSS_VARS,
+        # nicer defaults for built-in widgets
+        "block-cursor-foreground": COLORS["bg"],
+        "block-cursor-background": COLORS["accent"],
+        "input-selection-background": COLORS["teal"] + " 35%",
+    },
+)

--- a/apps/tui/dialogs.py
+++ b/apps/tui/dialogs.py
@@ -1,8 +1,9 @@
-"""Reusable modal dialogs for Hexis TUI."""
+"""Reusable modal dialogs for the Hexis TUI."""
 from __future__ import annotations
 
+from rich.text import Text
 from textual.app import ComposeResult
-from textual.containers import Vertical, Horizontal
+from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Label, Static
 
@@ -18,7 +19,7 @@ class ConfirmDialog(ModalScreen[bool]):
     def compose(self) -> ComposeResult:
         with Vertical(classes="dialog-box"):
             yield Label(self._title, classes="dialog-title")
-            yield Static(self._body, classes="dialog-body")
+            yield Static(Text(self._body), classes="dialog-body")
             with Horizontal(classes="dialog-buttons"):
                 yield Button("Yes", variant="success", id="yes")
                 yield Button("No", variant="error", id="no")
@@ -27,20 +28,29 @@ class ConfirmDialog(ModalScreen[bool]):
         self.dismiss(event.button.id == "yes")
 
 
-class ErrorDialog(ModalScreen[None]):
-    """Error display dialog with a single OK button."""
+class ErrorDialog(ModalScreen[bool]):
+    """Error dialog. Returns True only when the user chooses Retry.
 
-    def __init__(self, title: str, body: str) -> None:
+    Body is rendered as Rich ``Text`` so error strings containing brackets
+    (paths, tracebacks) never trip markup parsing.
+    """
+
+    def __init__(self, title: str, body: str, retry_label: str | None = None) -> None:
         super().__init__()
         self._title = title
         self._body = body
+        self._retry_label = retry_label
 
     def compose(self) -> ComposeResult:
         with Vertical(classes="dialog-box"):
             yield Label(self._title, classes="dialog-title")
-            yield Static(self._body, classes="dialog-body")
+            yield Static(Text(self._body), classes="dialog-body")
             with Horizontal(classes="dialog-buttons"):
-                yield Button("OK", variant="primary", id="ok")
+                if self._retry_label:
+                    yield Button(self._retry_label, variant="primary", id="retry")
+                    yield Button("Quit", variant="error", id="quit")
+                else:
+                    yield Button("OK", variant="primary", id="ok")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        self.dismiss(None)
+        self.dismiss(event.button.id == "retry")

--- a/apps/tui/hexis.tcss
+++ b/apps/tui/hexis.tcss
@@ -1,342 +1,206 @@
-/* Hexis TUI — shared stylesheet */
+/* Hexis TUI — shared stylesheet.
+   Colors come from the `hexis` theme (see design.py). Reference theme
+   variables ($primary, $secondary, $muted, $dim …) — never hard-code hex. */
 
 Screen {
-    background: #1a1a1a;
+    background: $background;
+    color: $foreground;
+    layers: base overlay;
 }
 
-/* ── Step bar ───────────────────────────────────────────── */
-
-StepBar {
-    height: 3;
-    dock: top;
-    background: #242424;
-    padding: 0 2;
-    content-align: center middle;
-}
-
-StepBar .step {
-    margin: 0 1;
-}
-
-StepBar .step--completed {
-    color: #4a9;
-}
-
-StepBar .step--active {
-    color: #d8774f;
-    text-style: bold;
-}
-
-StepBar .step--pending {
-    color: #4e463d;
-}
-
-StepBar .separator {
-    color: #4e463d;
-    margin: 0 1;
-}
-
-/* ── Buttons ────────────────────────────────────────────── */
+/* ── Buttons ─────────────────────────────────────────────────────────────── */
 
 Button {
     margin: 1 1;
     min-width: 12;
+    border: none;
+    height: 3;
 }
 
 Button.primary {
-    background: #d8774f;
-    color: #1a1a1a;
+    background: $primary;
+    color: $background;
+    text-style: bold;
 }
-
-Button.primary:hover {
-    background: #b45835;
-}
+Button.primary:hover { background: $accent; }
 
 Button.secondary {
-    background: #3c6f64;
-    color: #e0d8d0;
+    background: $secondary;
+    color: $foreground;
 }
-
-Button.secondary:hover {
-    background: #2d544c;
-}
+Button.secondary:hover { background: $teal-dim; }
 
 Button.muted {
-    background: #4e463d;
-    color: #e0d8d0;
+    background: $surface;
+    color: $dim;
 }
+Button.muted:hover { background: $elevated; color: $foreground; }
 
-/* ── Input fields ───────────────────────────────────────── */
+/* ── Inputs / Select ─────────────────────────────────────────────────────── */
 
-Input {
+Input, Select {
     margin: 1 0;
-    border: tall #4e463d;
+    border: tall $muted;
+    background: $surface;
 }
-
-Select {
-    margin: 1 0;
-    border: tall #4e463d;
-}
-
-Input:focus {
-    border: tall #d8774f;
-}
-
-Select:focus {
-    border: tall #d8774f;
-}
-
-Input.-valid {
-    border: tall #4a9;
-}
-
-/* ── Panels / containers ────────────────────────────────── */
-
-.panel {
-    background: #242424;
-    border: round #4e463d;
-    padding: 1 2;
-    margin: 1 0;
-}
-
-.panel-title {
-    color: #d8774f;
-    text-style: bold;
-}
-
-/* ── Chat messages ──────────────────────────────────────── */
-
-.msg-user {
-    color: #d8774f;
-    margin: 0 0 1 0;
-}
-
-.msg-assistant {
-    color: #e0d8d0;
-    margin: 0 0 1 0;
-}
-
-.msg-tool {
-    color: #4e463d;
-    text-style: italic;
-}
-
-.msg-error {
-    color: #c44;
-    text-style: bold;
-}
-
-/* ── Chat layout ────────────────────────────────────────── */
-
-#chat-column {
-    width: 1fr;
-}
-
-#chat-log {
-    height: 1fr;
-    border: round #4e463d;
-    padding: 0 1;
-    scrollbar-size: 1 1;
-}
-
-#chat-input {
-    dock: bottom;
-    height: 3;
-    margin: 0 0;
-}
-
-#context-sidebar {
-    width: 40;
-    display: none;
-    border-left: tall #4e463d;
-    padding: 0 1;
-    overflow-y: auto;
-}
-
-#context-sidebar.visible {
-    display: block;
-}
-
-/* ── Character gallery ──────────────────────────────────── */
-
-#character-gallery {
-    height: 1fr;
-}
-
-#char-table {
-    width: 2fr;
-    height: 1fr;
-}
-
-#char-preview {
-    width: 1fr;
-    min-width: 30;
-    border-left: tall #4e463d;
-    padding: 1 2;
-    height: 1fr;
-}
-
-/* ── Big Five sliders ───────────────────────────────────── */
-
-.big-five-row {
-    height: 3;
-    margin: 0 0;
-}
-
-.big-five-label {
-    width: 20;
-    content-align: right middle;
-    padding: 0 1;
-    color: #3c6f64;
-}
-
-.big-five-slider {
-    width: 1fr;
-}
-
-.big-five-value {
-    width: 8;
-    content-align: center middle;
-    color: #d8774f;
-}
-
-/* ── Init form layout ───────────────────────────────────── */
-
-.form-container {
-    padding: 1 4;
-    height: 1fr;
-    overflow-y: auto;
-}
-
-.form-group {
-    margin: 1 0;
-}
-
-.form-label {
-    color: #3c6f64;
-    margin: 0 0 0 0;
-}
-
-.button-bar {
-    dock: bottom;
-    height: 3;
-    align: center middle;
-    background: #242424;
-}
-
-/* ── RadioSet styling ───────────────────────────────────── */
+Input:focus, Select:focus { border: tall $primary; }
+Input.-valid { border: tall $success; }
 
 RadioSet {
     margin: 1 0;
-    border: round #4e463d;
+    border: round $muted;
     padding: 1 2;
+    background: $surface;
 }
-
-RadioSet:focus {
-    border: round #d8774f;
-}
-
-/* ── DataTable ──────────────────────────────────────────── */
+RadioSet:focus { border: round $primary; }
 
 DataTable {
     height: 1fr;
     scrollbar-size: 1 1;
+    background: $surface;
 }
+DataTable > .datatable--cursor { background: $secondary 35%; }
+DataTable > .datatable--header { color: $primary; text-style: bold; }
 
-DataTable > .datatable--cursor {
-    background: #3c6f64 30%;
+/* ── Panels ──────────────────────────────────────────────────────────────── */
+
+.panel {
+    background: $surface;
+    border: round $muted;
+    padding: 1 2;
+    margin: 1 0;
 }
-
-/* ── Consent / loading ──────────────────────────────────── */
-
-.consent-container {
+.panel-title { color: $primary; text-style: bold; }
+.form-container { padding: 1 4; height: 1fr; overflow-y: auto; }
+.form-label { color: $secondary; margin: 1 0 0 0; }
+.hint { color: $dim; }
+.button-bar {
+    dock: bottom;
+    height: 3;
     align: center middle;
-    width: 100%;
+    background: $surface;
+}
+
+/* ── Step bar (init) ─────────────────────────────────────────────────────── */
+
+StepBar {
+    height: 3;
+    dock: top;
+    background: $surface;
+    padding: 0 2;
+    content-align: center middle;
+}
+
+/* ── Big-Five slider (init) ──────────────────────────────────────────────── */
+
+.big-five-row { height: 1; margin: 0 0; }
+.big-five-label {
+    width: 20;
+    content-align: right middle;
+    padding: 0 1;
+    color: $secondary;
+}
+TraitSlider { width: 1fr; height: 1; }
+TraitSlider:focus { color: $primary; }
+
+/* ── Character gallery (init) ────────────────────────────────────────────── */
+
+#character-gallery { height: 1fr; }
+#char-table { width: 2fr; height: 1fr; }
+#char-preview {
+    width: 1fr;
+    min-width: 32;
+    border-left: tall $muted;
+    padding: 1 2;
     height: 1fr;
-    padding: 1 4;
+    background: $surface;
 }
 
-.consent-result {
-    width: 100%;
-    height: 1fr;
-    padding: 1 4;
-    overflow-y: auto;
-}
+/* ── Consent (init) ──────────────────────────────────────────────────────── */
 
-/* ── Dialogs ────────────────────────────────────────────── */
+.consent-container { align: center middle; width: 100%; height: 1fr; padding: 1 4; }
+.consent-result { width: 100%; height: 1fr; padding: 1 4; overflow-y: auto; }
+#consent-countdown { color: $dim; height: 1; padding: 0 4; }
 
-ConfirmDialog, ErrorDialog {
-    align: center middle;
-}
+/* ── Dialogs ─────────────────────────────────────────────────────────────── */
 
+ConfirmDialog, ErrorDialog { align: center middle; }
 ConfirmDialog .dialog-box, ErrorDialog .dialog-box {
-    width: 50;
+    width: 60;
     height: auto;
-    max-height: 20;
-    border: round #4e463d;
-    background: #242424;
+    max-height: 22;
+    border: round $muted;
+    background: $surface;
     padding: 2 4;
 }
+.dialog-title { text-align: center; text-style: bold; color: $primary; margin: 0 0 1 0; }
+.dialog-body { text-align: center; margin: 0 0 2 0; color: $foreground; }
+.dialog-buttons { align: center middle; height: 3; }
 
-.dialog-title {
-    text-align: center;
-    text-style: bold;
-    color: #d8774f;
-    margin: 0 0 1 0;
-}
+/* ── Chat ────────────────────────────────────────────────────────────────── */
 
-.dialog-body {
-    text-align: center;
-    margin: 0 0 2 0;
-}
-
-.dialog-buttons {
-    align: center middle;
-    height: 3;
-}
-
-
-/* ── ToolCallBar ────────────────────────────────────────── */
-
-.tool-indicator {
-    color: #4e463d;
-    text-style: italic;
-    margin: 0 0 0 2;
-}
-
-.tool-success {
-    color: #4a9;
-}
-
-.tool-failure {
-    color: #c44;
-}
-
-/* ── Header bar ─────────────────────────────────────────── */
-
-.chat-header {
+#chat-header {
     dock: top;
     height: 1;
-    background: #242424;
+    background: $surface;
     padding: 0 2;
-    color: #e0d8d0;
+    color: $foreground;
 }
 
-.chat-header .agent-name {
-    text-style: bold;
-    color: #d8774f;
+#transcript {
+    height: 1fr;
+    padding: 0 1;
+    scrollbar-size: 1 1;
+    background: $background;
 }
 
-.chat-header .agent-meta {
-    color: #4e463d;
+/* one grouped turn */
+.turn { height: auto; padding: 0 0 1 0; }
+.role-label { height: 1; text-style: bold; }
+.role-user { color: $primary; }
+.role-assistant { color: $secondary; }
+.msg-body { padding: 0 0 0 2; height: auto; }
+.msg-body Markdown { background: $background; margin: 0; }
+.msg-info { color: $dim; padding: 0 0 0 2; }
+.msg-error { color: $error; text-style: bold; padding: 0 0 0 2; }
+
+/* streaming block */
+StreamingBlock { padding: 0 0 0 2; height: auto; color: $foreground; }
+
+/* reasoning — dim, dashed, downplayed */
+.reasoning {
+    margin: 0 0 0 2;
+    border: dashed $muted;
+    color: $dim;
+    background: $surface;
 }
+.reasoning > .collapsible--title { color: $dim; }
 
-/* ── Footer ─────────────────────────────────────────────── */
+/* tool tree */
+.tool-tree { margin: 0 0 0 2; color: $dim; height: auto; }
+.tool-tree > .collapsible--title { color: $secondary; }
+.tool-line { height: auto; color: $dim; }
 
-.chat-footer {
+/* composer */
+#composer {
+    height: 3;
+    margin: 0;
+    border: tall $muted;
+    background: $surface;
+}
+#composer:focus { border: tall $primary; }
+
+.queued-hint { height: 1; color: $dim; padding: 0 2; background: $surface; }
+
+/* slash-command menu */
+SlashMenu {
+    layer: overlay;
     dock: bottom;
-    height: 1;
-    background: #242424;
-    padding: 0 2;
-    color: #4e463d;
+    width: 100%;
+    height: auto;
+    max-height: 10;
+    margin: 0 0 4 0;
+    background: $elevated;
+    border: round $muted;
 }
+SlashMenu > .option-list--option-highlighted { background: $secondary 35%; color: $strong; }

--- a/apps/tui/hexis.tcss
+++ b/apps/tui/hexis.tcss
@@ -54,6 +54,17 @@ RadioSet {
 }
 RadioSet:focus { border: round $primary; }
 
+/* Model combobox dropdown (inline, under the model field) */
+ModelMenu {
+    max-height: 9;
+    height: auto;
+    margin: 0 0 1 0;
+    border: round $muted;
+    background: $elevated;
+}
+ModelMenu:focus { border: round $primary; }
+ModelMenu > .option-list--option-highlighted { background: $secondary 35%; color: $strong; }
+
 DataTable {
     height: 1fr;
     scrollbar-size: 1 1;
@@ -120,7 +131,6 @@ TraitSlider:focus { color: $primary; }
 
 .consent-container { align: center middle; width: 100%; height: 1fr; padding: 1 4; }
 .consent-result { width: 100%; height: 1fr; padding: 1 4; overflow-y: auto; }
-#consent-countdown { color: $dim; height: 1; padding: 0 4; }
 
 /* ── Dialogs ─────────────────────────────────────────────────────────────── */
 
@@ -136,6 +146,15 @@ ConfirmDialog .dialog-box, ErrorDialog .dialog-box {
 .dialog-title { text-align: center; text-style: bold; color: $primary; margin: 0 0 1 0; }
 .dialog-body { text-align: center; margin: 0 0 2 0; color: $foreground; }
 .dialog-buttons { align: center middle; height: 3; }
+
+/* Inline Anthropic OAuth login — wider box for the auth URL + code input */
+#anthropic-login-box {
+    width: 84;
+    max-height: 26;
+    height: auto;
+}
+#anthropic-login-url { color: $dim; margin: 0 0 1 0; }
+#anthropic-login-status { height: auto; margin: 1 0 0 0; }
 
 /* ── Chat ────────────────────────────────────────────────────────────────── */
 

--- a/apps/tui/init_app.py
+++ b/apps/tui/init_app.py
@@ -68,6 +68,10 @@ class InitState:
     consent_reasoning: str = ""
     consent_signature: str = ""
     consent_memories: list[dict[str, Any]] = field(default_factory=list)
+    # When the agent refuses consent, the user can change the model and retry;
+    # this flag routes the LLM screen straight back to consent (identity is
+    # already persisted) instead of re-walking the whole wizard.
+    retry_consent: bool = False
 
     # Final
     final_agent_name: str = ""
@@ -93,12 +97,23 @@ class HexisInitApp(App):
         self.state = InitState()
         self._argv = argv or []
         self._conn: Any = None
+        # Set by the final consent screen so the CLI can hand off to chat / ui
+        # after init exits: "chat" | "ui" | None.
+        self.next_action: str | None = None
 
     def get_css_variables(self) -> dict[str, str]:
         from apps.tui.design import CSS_VARS
         variables = super().get_css_variables()
         variables.update(CSS_VARS)
         return variables
+
+    def run(self, **kwargs):
+        # Keyboard-only by default: don't capture the mouse, so the terminal's
+        # native click-drag text selection / copy keeps working. Set
+        # HEXIS_TUI_MOUSE=1 to re-enable mouse interaction.
+        import os
+        kwargs.setdefault("mouse", os.getenv("HEXIS_TUI_MOUSE", "") == "1")
+        return super().run(**kwargs)
 
     async def on_mount(self) -> None:
         load_dotenv()
@@ -142,8 +157,32 @@ class HexisInitApp(App):
             )
             return
 
-        from apps.tui.init_screens import LLMConfigScreen
-        await self.push_screen(LLMConfigScreen())
+        await self._start_wizard()
+
+    async def _start_wizard(self) -> None:
+        """If an agent is already configured, offer keep-or-reconfigure first."""
+        from apps.tui.init_screens import LLMConfigScreen, ReconfigureScreen
+
+        summary: dict[str, Any] | None = None
+        try:
+            configured = bool(await self._conn.fetchval("SELECT is_agent_configured()"))
+            if configured:
+                raw = await self._conn.fetchval("SELECT get_init_profile()")
+                profile = json.loads(raw) if isinstance(raw, str) else (raw or {})
+                llm = await self._conn.fetchval("SELECT get_config('llm.chat')")
+                llm = json.loads(llm) if isinstance(llm, str) else (llm or {})
+                summary = {
+                    "name": (profile.get("agent", {}) or {}).get("name", "your agent"),
+                    "provider": llm.get("provider", "?"),
+                    "model": llm.get("model", "?"),
+                }
+        except Exception:
+            summary = None
+
+        if summary is not None:
+            await self.push_screen(ReconfigureScreen(summary))
+        else:
+            await self.push_screen(LLMConfigScreen())
 
     @property
     def conn(self) -> Any:

--- a/apps/tui/init_app.py
+++ b/apps/tui/init_app.py
@@ -94,6 +94,12 @@ class HexisInitApp(App):
         self._argv = argv or []
         self._conn: Any = None
 
+    def get_css_variables(self) -> dict[str, str]:
+        from apps.tui.design import CSS_VARS
+        variables = super().get_css_variables()
+        variables.update(CSS_VARS)
+        return variables
+
     async def on_mount(self) -> None:
         load_dotenv()
         from core.agent_api import db_dsn_from_env, ensure_schema_has_config, _connect_with_retry
@@ -114,13 +120,26 @@ class HexisInitApp(App):
 
         self.state.dsn = dsn or db_dsn_from_env()
         self.state.wait_seconds = wait_seconds
+        await self._attempt_connect()
+
+    async def _attempt_connect(self) -> None:
+        from core.agent_api import ensure_schema_has_config, _connect_with_retry
 
         try:
-            await ensure_schema_has_config(self.state.dsn, wait_seconds=wait_seconds)
-            self._conn = await _connect_with_retry(self.state.dsn, wait_seconds=wait_seconds)
+            await ensure_schema_has_config(self.state.dsn, wait_seconds=self.state.wait_seconds)
+            self._conn = await _connect_with_retry(self.state.dsn, wait_seconds=self.state.wait_seconds)
         except Exception as e:
             from apps.tui.dialogs import ErrorDialog
-            await self.push_screen(ErrorDialog("Connection Error", str(e)))
+
+            def _on_choice(retry: bool | None) -> None:
+                if retry:
+                    self.call_later(self._attempt_connect)
+                else:
+                    self.exit(1)
+
+            await self.push_screen(
+                ErrorDialog("Connection Error", str(e), retry_label="Retry"), _on_choice
+            )
             return
 
         from apps.tui.init_screens import LLMConfigScreen

--- a/apps/tui/init_screens.py
+++ b/apps/tui/init_screens.py
@@ -22,8 +22,19 @@ from textual.widgets import (
     Static,
 )
 from textual.worker import Worker, WorkerState
+from rich.style import Style
+from rich.text import Text
 
+from apps.tui.design import COLORS
 from apps.tui.init_widgets import BigFiveSliders, CharacterPreview, StepBar
+
+
+def _teal(text: str) -> Text:
+    return Text(text, style=Style(color=COLORS["teal"], bold=True))
+
+
+def _plain(text: str, token: str = "text") -> Text:
+    return Text(text, style=Style(color=COLORS[token]))
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -160,6 +171,7 @@ class LLMConfigScreen(Screen):
                 placeholder="e.g. OPENAI_API_KEY",
                 id="api-key-env",
             )
+            yield Static("", id="llm-status", classes="hint")
 
         with Horizontal(classes="button-bar"):
             yield Button("Next", id="next", classes="primary")
@@ -291,67 +303,79 @@ class LLMConfigScreen(Screen):
         )
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "next":
-            state = _state(self)
-            conn = _conn(self)
+        if event.button.id != "next":
+            return
+        state = _state(self)
 
-            state.provider = self._selected_provider()
-            state.model = self.query_one("#model", Input).value.strip()
-            state.endpoint = self.query_one("#endpoint", Input).value.strip()
-            state.api_key_env = self.query_one("#api-key-env", Input).value.strip()
-            if state.provider in _OAUTH_PROVIDERS:
-                # OAuth providers don't use API key env vars in llm config.
-                state.api_key_env = ""
+        state.provider = self._selected_provider()
+        state.model = self.query_one("#model", Input).value.strip()
+        state.endpoint = self.query_one("#endpoint", Input).value.strip()
+        state.api_key_env = self.query_one("#api-key-env", Input).value.strip()
+        if state.provider in _OAUTH_PROVIDERS:
+            # OAuth providers don't use API key env vars in llm config.
+            state.api_key_env = ""
 
-            # Subconscious defaults to same config
-            state.sub_provider = state.provider
-            state.sub_model = state.model
-            state.sub_endpoint = state.endpoint
-            state.sub_key_env = state.api_key_env
+        # Subconscious defaults to same config
+        state.sub_provider = state.provider
+        state.sub_model = state.model
+        state.sub_endpoint = state.endpoint
+        state.sub_key_env = state.api_key_env
 
-            # Save to DB
-            heartbeat_config = {
-                "provider": state.provider,
-                "model": state.model,
-                "endpoint": state.endpoint,
-                "api_key_env": state.api_key_env,
-            }
-            subconscious_config = {
-                "provider": state.sub_provider,
-                "model": state.sub_model,
-                "endpoint": state.sub_endpoint,
-                "api_key_env": state.sub_key_env,
-            }
+        self._hb_config = {
+            "provider": state.provider,
+            "model": state.model,
+            "endpoint": state.endpoint,
+            "api_key_env": state.api_key_env,
+        }
+        self._sub_config = {
+            "provider": state.sub_provider,
+            "model": state.sub_model,
+            "endpoint": state.sub_endpoint,
+            "api_key_env": state.sub_key_env,
+        }
 
-            try:
-                await self._ensure_provider_auth(state.provider)
-                await conn.fetchval(
-                    "SELECT init_llm_config($1::jsonb, $2::jsonb)",
-                    json.dumps(heartbeat_config),
-                    json.dumps(subconscious_config),
-                )
-                await conn.execute(
-                    "SELECT set_config('llm.heartbeat', $1::jsonb)",
-                    json.dumps(heartbeat_config),
-                )
-                await conn.execute(
-                    "SELECT set_config('llm.chat', $1::jsonb)",
-                    json.dumps(heartbeat_config),
-                )
-                await conn.execute(
-                    "SELECT set_config('llm.subconscious', $1::jsonb)",
-                    json.dumps(subconscious_config),
-                )
-            except RuntimeError as e:
-                from apps.tui.dialogs import ErrorDialog
-                await self.app.push_screen(ErrorDialog("Auth Error", str(e)))
-                return
-            except Exception as e:
-                from apps.tui.dialogs import ErrorDialog
-                await self.app.push_screen(ErrorDialog("DB Error", str(e)))
-                return
+        # Run auth + persistence off the UI thread so the form never freezes
+        # (OAuth can block on a browser round-trip).
+        self.query_one("#next", Button).disabled = True
+        status = self.query_one("#llm-status", Static)
+        if state.provider in _OAUTH_PROVIDERS:
+            status.update(Text("Authorizing… a browser window may open — finish login there.",
+                               style=Style(color=COLORS["accent"])))
+        else:
+            status.update(Text("Saving configuration…", style=Style(color=COLORS["dim"])))
+        self.run_worker(self._authorize_and_save(), name="llm-auth", exclusive=True)
 
+    async def _authorize_and_save(self) -> None:
+        state = _state(self)
+        conn = _conn(self)
+        await self._ensure_provider_auth(state.provider)
+        await conn.fetchval(
+            "SELECT init_llm_config($1::jsonb, $2::jsonb)",
+            json.dumps(self._hb_config),
+            json.dumps(self._sub_config),
+        )
+        await conn.execute(
+            "SELECT set_config('llm.heartbeat', $1::jsonb)", json.dumps(self._hb_config)
+        )
+        await conn.execute(
+            "SELECT set_config('llm.chat', $1::jsonb)", json.dumps(self._hb_config)
+        )
+        await conn.execute(
+            "SELECT set_config('llm.subconscious', $1::jsonb)", json.dumps(self._sub_config)
+        )
+
+    async def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if event.worker.name != "llm-auth":
+            return
+        if event.state == WorkerState.SUCCESS:
             self.app.switch_screen(ChoosePathScreen())
+        elif event.state == WorkerState.ERROR:
+            err = event.worker.error
+            self.query_one("#next", Button).disabled = False
+            self.query_one("#llm-status", Static).update("")
+            from apps.tui.dialogs import ErrorDialog
+            title = "Auth Error" if isinstance(err, RuntimeError) else "DB Error"
+            await self.app.push_screen(ErrorDialog(title, str(err)))
 
 
 # ── 3. Choose Path ───────────────────────────────────────────────────────────
@@ -740,7 +764,7 @@ class ConsentScreen(Screen):
     _countdown: int = 10
 
     def compose(self) -> ComposeResult:
-        yield StepBar(current=2)
+        yield StepBar(current=3)
         with Vertical(classes="consent-container", id="consent-loading"):
             yield LoadingIndicator()
             yield Static(
@@ -748,7 +772,10 @@ class ConsentScreen(Screen):
                 id="consent-status",
             )
         with VerticalScroll(classes="consent-result", id="consent-result"):
-            yield RichLog(id="consent-log", wrap=True, markup=True)
+            # markup=False → the agent's reasoning/signature (model output, may
+            # contain brackets) is written as Rich Text, never re-parsed.
+            yield RichLog(id="consent-log", wrap=True, markup=False)
+        yield Static("", id="consent-countdown")
         with Horizontal(classes="button-bar"):
             yield Button("Exit Now", id="exit-now", classes="primary", disabled=True)
 
@@ -826,27 +853,27 @@ class ConsentScreen(Screen):
         state.consent_memories = memories
 
         if reasoning:
-            log.write("[#3c6f64]Reasoning:[/#3c6f64]")
-            log.write(reasoning)
+            log.write(_teal("Reasoning:"))
+            log.write(_plain(str(reasoning)))
             log.write("")
 
         if signature:
-            log.write("[#3c6f64]Signature:[/#3c6f64]")
-            log.write(signature)
+            log.write(_teal("Signature:"))
+            log.write(_plain(str(signature)))
             log.write("")
 
         if memories:
-            log.write("[#3c6f64]Initial Memories:[/#3c6f64]")
+            log.write(_teal("Initial Memories:"))
             for m in memories:
                 mtype = m.get("type", "?")
                 mcontent = m.get("content", "")
                 mimp = m.get("importance", "")
                 imp_str = f" (importance: {mimp})" if mimp else ""
-                log.write(f"  [{mtype}] {mcontent}{imp_str}")
+                log.write(_plain(f"  [{mtype}] {mcontent}{imp_str}"))
             log.write("")
 
         if decision == "consent":
-            log.write("[green]Consent granted[/green]")
+            log.write(Text("Consent granted", style=Style(color=COLORS["ok"], bold=True)))
             # Show agent name + next steps, then auto-exit
             agent_name = "Hexis"
             conn = _conn(self)
@@ -858,31 +885,36 @@ class ConsentScreen(Screen):
                 pass
             state.final_agent_name = agent_name
             log.write("")
-            log.write(f"[bold #d8774f]{agent_name} is ready![/bold #d8774f]")
+            log.write(Text(f"{agent_name} is ready!", style=Style(color=COLORS["accent"], bold=True)))
             log.write("")
-            log.write("[#3c6f64]Next steps:[/#3c6f64]")
-            log.write("  [bold]hexis chat[/bold]    \u2014 Say hello")
-            log.write("  [bold]hexis status[/bold]  \u2014 Check agent status")
-            log.write("  [bold]hexis start[/bold]   \u2014 Enable heartbeat")
-            log.write("")
+            log.write(_teal("Next steps:"))
+            log.write(_plain("  hexis chat    \u2014 Say hello"))
+            log.write(_plain("  hexis status  \u2014 Check agent status"))
+            log.write(_plain("  hexis start   \u2014 Enable heartbeat"))
             self._countdown = 10
-            log.write(f"Exiting in {self._countdown}s...")
+            self._render_countdown()
             self.query_one("#exit-now", Button).disabled = False
             self.set_timer(1.0, self._tick_countdown)
         elif decision == "decline":
-            log.write("[red]Consent declined.[/red] The agent chose not to initialize.")
+            log.write(Text("Consent declined \u2014 the agent chose not to initialize.",
+                           style=Style(color=COLORS["danger"], bold=True)))
             self.query_one("#exit-now", Button).disabled = False
         else:
-            log.write("[yellow]Consent abstained.[/yellow]")
+            log.write(Text("Consent abstained.", style=Style(color=COLORS["warn"], bold=True)))
             self.query_one("#exit-now", Button).disabled = False
+
+    def _render_countdown(self) -> None:
+        self.query_one("#consent-countdown", Static).update(
+            Text(f"Exiting in {self._countdown}s\u2026  (press Exit Now to leave immediately)",
+                 style=Style(color=COLORS["dim"]))
+        )
 
     def _tick_countdown(self) -> None:
         self._countdown -= 1
         if self._countdown <= 0:
             self.app.exit(0)
             return
-        log = self.query_one("#consent-log", RichLog)
-        log.write(f"Exiting in {self._countdown}s...")
+        self._render_countdown()  # updates one line in place, no log spam
         self.set_timer(1.0, self._tick_countdown)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/apps/tui/init_screens.py
+++ b/apps/tui/init_screens.py
@@ -7,14 +7,16 @@ import os
 from typing import Any
 
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.screen import Screen
+from textual.screen import ModalScreen, Screen
 from textual.widgets import (
     Button,
     DataTable,
     Input,
     Label,
     LoadingIndicator,
+    OptionList,
     RadioButton,
     RadioSet,
     RichLog,
@@ -26,7 +28,13 @@ from rich.style import Style
 from rich.text import Text
 
 from apps.tui.design import COLORS
-from apps.tui.init_widgets import BigFiveSliders, CharacterPreview, StepBar
+from apps.tui.init_widgets import (
+    BigFiveSliders,
+    CharacterPreview,
+    ModelCombo,
+    ModelMenu,
+    StepBar,
+)
 
 
 def _teal(text: str) -> Text:
@@ -41,6 +49,7 @@ def _plain(text: str, token: str = "text") -> Text:
 
 _DEFAULT_MODELS: dict[str, str] = {
     "anthropic": "claude-sonnet-4-20250514",
+    "anthropic-oauth": "claude-sonnet-5",
     "openai": "gpt-4o",
     "openai-codex": "gpt-5.2",
     "grok": "grok-3",
@@ -56,6 +65,7 @@ _DEFAULT_MODELS: dict[str, str] = {
 
 _PROVIDER_ENV_VARS: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
+    "anthropic-oauth": "",
     "openai": "OPENAI_API_KEY",
     "openai-codex": "",
     "grok": "XAI_API_KEY",
@@ -72,7 +82,8 @@ _PROVIDER_ENV_VARS: dict[str, str] = {
 _PROVIDER_OPTIONS: list[tuple[str, str]] = [
     ("OpenAI Codex (ChatGPT OAuth)", "openai-codex"),
     ("OpenAI Platform (API key)", "openai"),
-    ("Anthropic", "anthropic"),
+    ("Claude Pro/Max (Anthropic OAuth)", "anthropic-oauth"),
+    ("Anthropic (API key)", "anthropic"),
     ("Grok (xAI)", "grok"),
     ("Gemini", "gemini"),
     ("Ollama (local)", "ollama"),
@@ -86,6 +97,7 @@ _PROVIDER_OPTIONS: list[tuple[str, str]] = [
 
 _OAUTH_PROVIDERS: set[str] = {
     "openai-codex",
+    "anthropic-oauth",
     "chutes",
     "github-copilot",
     "qwen-portal",
@@ -95,10 +107,21 @@ _OAUTH_PROVIDERS: set[str] = {
 }
 
 
+def _persisted_provider(provider: str) -> str:
+    """Map a wizard-only provider alias to the id the LLM layer understands.
+
+    ``anthropic-oauth`` is a UI convenience; it persists as ``anthropic`` with
+    an empty api_key so ``load_llm_config`` auto-resolves the OAuth/Claude Code
+    token at runtime.
+    """
+    return "anthropic" if provider == "anthropic-oauth" else provider
+
+
 def _normalize_provider(raw: str) -> str:
     val = (raw or "").strip().lower()
     aliases = {
         "openai_codex": "openai-codex",
+        "anthropic_oauth": "anthropic-oauth",
         "github_copilot": "github-copilot",
         "qwen_portal": "qwen-portal",
         "minimax_portal": "minimax-portal",
@@ -116,6 +139,157 @@ def _state(screen: Screen) -> Any:
 def _conn(screen: Screen) -> Any:
     """Get the DB connection from the app."""
     return screen.app.conn  # type: ignore[attr-defined]
+
+
+# ── Already-configured: keep or reconfigure ──────────────────────────────────
+
+class ReconfigureScreen(Screen):
+    """Shown when `hexis init` runs on an already-configured agent.
+
+    Non-destructive: nothing changes unless the user chooses to reconfigure.
+    """
+
+    def __init__(self, summary: dict[str, Any]) -> None:
+        super().__init__()
+        self._summary = summary
+
+    def compose(self) -> ComposeResult:
+        s = self._summary
+        with VerticalScroll(classes="form-container"):
+            yield Static(Text(f"{s.get('name', 'Your agent')} is already set up",
+                              style=Style(color=COLORS["accent"], bold=True)))
+            yield Static("")
+            line = Text()
+            line.append("Model: ", style=Style(color=COLORS["teal"]))
+            line.append(f"{s.get('provider', '?')} / {s.get('model', '?')}",
+                        style=Style(color=COLORS["text"]))
+            yield Static(line)
+            yield Static("")
+            yield Static(_plain(
+                "Reconfiguring walks through setup again and overwrites the "
+                "current configuration. Keeping leaves everything as-is.", "dim"))
+        with Horizontal(classes="button-bar"):
+            yield Button("Keep — exit", id="keep", classes="muted")
+            yield Button("Reconfigure", id="reconfigure", classes="primary")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "reconfigure":
+            self.app.switch_screen(LLMConfigScreen())
+        elif event.button.id == "keep":
+            self.app.exit(0)
+
+
+# ── Anthropic OAuth login (inline, in-wizard) ────────────────────────────────
+
+class AnthropicLoginScreen(ModalScreen[bool]):
+    """In-wizard Claude Pro/Max login (Anthropic OAuth PKCE).
+
+    Opens the browser to the authorize URL, the user pastes the code Anthropic
+    shows, and we exchange it for a token saved to Hexis's own store. Dismisses
+    True on success, False on cancel.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._verifier = ""
+        self._state = ""
+        self._auth_url = ""
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="dialog-box", id="anthropic-login-box"):
+            yield Label("Claude Pro/Max Login", classes="dialog-title")
+            yield Static(
+                Text(
+                    "A browser window is opening. Authorize with your Claude "
+                    "Pro/Max subscription, copy the code Anthropic shows you, "
+                    "and paste it below. This replaces any existing Hexis "
+                    "Anthropic login.",
+                    style=Style(color=COLORS["text"]),
+                ),
+                classes="dialog-body",
+            )
+            yield Static("", id="anthropic-login-url", classes="hint")
+            yield Input(placeholder="Paste the authorization code (code#state)",
+                        id="anthropic-code")
+            yield Static("", id="anthropic-login-status", classes="hint")
+            with Horizontal(classes="dialog-buttons"):
+                yield Button("Reopen Browser", id="reopen", classes="muted")
+                yield Button("Submit", id="submit", classes="primary")
+                yield Button("Cancel", id="cancel", classes="muted")
+
+    def on_mount(self) -> None:
+        from core.auth import create_state, generate_pkce
+        from core.auth.anthropic_oauth import build_authorize_url
+
+        self._verifier, challenge = generate_pkce()
+        self._state = create_state()
+        self._auth_url = build_authorize_url(challenge=challenge, state=self._state)
+        self._open_browser()
+        self.query_one("#anthropic-login-url", Static).update(
+            Text(f"If the browser didn't open, visit:\n{self._auth_url}",
+                 style=Style(color=COLORS["dim"]))
+        )
+        self.query_one("#anthropic-code", Input).focus()
+
+    def _open_browser(self) -> None:
+        import webbrowser
+        try:
+            webbrowser.open(self._auth_url)
+        except Exception:
+            pass
+
+    def _set_status(self, text: str, token: str) -> None:
+        self.query_one("#anthropic-login-status", Static).update(
+            Text(text, style=Style(color=COLORS[token]))
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss(False)
+        elif event.button.id == "reopen":
+            self._open_browser()
+        elif event.button.id == "submit":
+            self._submit()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "anthropic-code":
+            self._submit()
+
+    def _submit(self) -> None:
+        pasted = self.query_one("#anthropic-code", Input).value.strip()
+        if not pasted:
+            self._set_status("Paste the authorization code first.", "warn")
+            return
+        self.query_one("#submit", Button).disabled = True
+        self._set_status("Exchanging code for a token…", "dim")
+        self.run_worker(self._exchange(pasted), name="anthropic-exchange",
+                        exclusive=True, exit_on_error=False)
+
+    async def _exchange(self, pasted: str) -> None:
+        from core.auth.anthropic_oauth import (
+            exchange_authorization_code,
+            parse_authorization_input,
+            save_credentials,
+        )
+
+        code, pasted_state = parse_authorization_input(pasted)
+        if pasted_state and pasted_state != self._state:
+            raise RuntimeError("State mismatch — reopen the browser and try again.")
+        if not code:
+            raise RuntimeError("Missing authorization code.")
+        creds = await exchange_authorization_code(
+            code=code, verifier=self._verifier, state=pasted_state or self._state,
+        )
+        save_credentials(creds)
+
+    async def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if event.worker.name != "anthropic-exchange":
+            return
+        if event.state == WorkerState.SUCCESS:
+            self.dismiss(True)
+        elif event.state == WorkerState.ERROR:
+            self.query_one("#submit", Button).disabled = False
+            self._set_status(f"Login failed: {event.worker.error}", "danger")
 
 
 # ── 1. LLM Config ───────────────────────────────────────────────────────────
@@ -152,11 +326,12 @@ class LLMConfigScreen(Screen):
             yield Static("", id="provider-help", classes="form-label")
 
             yield Label("Model", classes="form-label")
-            yield Input(
+            yield ModelCombo(
                 value=model_default,
-                placeholder="Model name",
+                placeholder="Type a model, or ↓ to pick from the list",
                 id="model",
             )
+            yield ModelMenu(id="model-menu")
 
             yield Label("Endpoint (blank for provider default)", classes="form-label")
             yield Input(
@@ -172,8 +347,14 @@ class LLMConfigScreen(Screen):
                 id="api-key-env",
             )
             yield Static("", id="llm-status", classes="hint")
+            yield Static(
+                Text("Tip: you can change any of this later with `hexis init`.",
+                     style=Style(color=COLORS["dim"])),
+                classes="hint",
+            )
 
         with Horizontal(classes="button-bar"):
+            yield Button("Test connection", id="test-conn", classes="secondary")
             yield Button("Next", id="next", classes="primary")
 
     def _selected_provider(self) -> str:
@@ -208,6 +389,11 @@ class LLMConfigScreen(Screen):
             key_input.disabled = True
             if provider == "openai-codex":
                 help_text.update("Next opens browser OAuth for ChatGPT Plus/Pro.")
+            elif provider == "anthropic-oauth":
+                help_text.update(
+                    "Uses your Claude Pro/Max subscription via Hexis's own "
+                    "login. Run `hexis auth anthropic login` first if needed."
+                )
             else:
                 help_text.update("Next runs provider OAuth/device-code login.")
         else:
@@ -228,12 +414,82 @@ class LLMConfigScreen(Screen):
             preserve_model=bool(os.getenv("LLM_MODEL")),
             preserve_endpoint=True,
         )
+        self._load_models()
 
     def on_select_changed(self, event: Select.Changed) -> None:
         if event.select.id != "provider":
             return
         provider = _normalize_provider(str(event.value)) if isinstance(event.value, str) else "openai"
         self._apply_provider_defaults(provider)
+        self.query_one("#model-menu", ModelMenu).hide()
+        self._load_models()
+
+    # ── model dropdown ───────────────────────────────────────────────────────
+    def _load_models(self) -> None:
+        provider = self._selected_provider()
+        try:
+            endpoint = self.query_one("#endpoint", Input).value.strip()
+        except Exception:
+            endpoint = ""
+        self.run_worker(self._fetch_models(provider, endpoint),
+                        name="model-fetch", group="model-fetch", exclusive=True,
+                        exit_on_error=False)
+
+    async def _fetch_models(self, provider: str, endpoint: str) -> None:
+        from apps.tui import model_catalog
+        models = await model_catalog.fetch_models(provider, endpoint=endpoint or None)
+        try:
+            self.query_one("#model-menu", ModelMenu).populate(models)
+        except Exception:
+            pass
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "model":
+            return
+        menu = self.query_one("#model-menu", ModelMenu)
+        if menu._suppress:
+            menu._suppress = False
+            menu.hide()
+            self._model_advisory(event.value)
+            return
+        menu.apply_filter(event.value)
+        self._model_advisory(event.value)
+
+    def _model_advisory(self, value: str) -> None:
+        """Soft, non-blocking hint: unknown model name or missing API key."""
+        import os as _os
+
+        status = self.query_one("#llm-status", Static)
+        provider = self._selected_provider()
+        menu = self.query_one("#model-menu", ModelMenu)
+        val = (value or "").strip()
+
+        if val and menu._all and val not in menu._all:
+            status.update(Text(
+                f"Heads up: “{val}” isn't in the known list for {provider} — "
+                "double-check the spelling (custom names are fine).",
+                style=Style(color=COLORS["warn"])))
+            return
+        if provider not in _OAUTH_PROVIDERS and provider != "ollama":
+            key_env = self.query_one("#api-key-env", Input).value.strip()
+            if key_env and not _os.getenv(key_env):
+                status.update(Text(
+                    f"Note: ${key_env} isn't set in this environment yet — "
+                    "the model won't respond until it is.",
+                    style=Style(color=COLORS["dim"])))
+                return
+        status.update("")
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if event.option_list.id != "model-menu":
+            return
+        menu = self.query_one("#model-menu", ModelMenu)
+        combo = self.query_one("#model", ModelCombo)
+        menu._suppress = True
+        combo.value = event.option.id or ""
+        combo.cursor_position = len(combo.value)
+        menu.hide()
+        combo.focus()
 
     async def _ensure_openai_codex_login(self) -> None:
         import socket
@@ -284,11 +540,29 @@ class LLMConfigScreen(Screen):
         save_openai_codex_credentials(creds)
         await ensure_fresh_openai_codex_credentials(skew_seconds=0)
 
+    async def _login_anthropic_oauth(self) -> None:
+        """Always run the Claude Pro/Max login, overwriting any existing token.
+
+        `hexis init` should just log the user in fresh whether or not a
+        credential already exists — never silently reuse a stale one. The login
+        runs inline (browser + paste code) and saves to Hexis's OWN store
+        (``~/.hexis/auth/``), overwriting the previous token. Called from the
+        auth worker, so ``push_screen_wait`` is valid here.
+        """
+        from core.auth.anthropic_oauth import load_credentials
+
+        ok = await self.app.push_screen_wait(AnthropicLoginScreen())
+        if not ok or not load_credentials():
+            raise RuntimeError("Claude Pro/Max login was cancelled or did not complete.")
+
     async def _ensure_provider_auth(self, provider: str) -> None:
         if provider not in _OAUTH_PROVIDERS:
             return
         if provider == "openai-codex":
             await self._ensure_openai_codex_login()
+            return
+        if provider == "anthropic-oauth":
+            await self._login_anthropic_oauth()
             return
 
         from apps.hexis_init import _ensure_oauth_login
@@ -302,7 +576,46 @@ class LLMConfigScreen(Screen):
             allow_manual_fallback=False,
         )
 
+    def _test_connection(self) -> None:
+        """Advisory: make one real call to check the current form's config works."""
+        import os as _os
+
+        provider = self._selected_provider()
+        status = self.query_one("#llm-status", Static)
+        if provider in _OAUTH_PROVIDERS:
+            status.update(Text(
+                "OAuth providers are verified when you sign in on Next.",
+                style=Style(color=COLORS["dim"])))
+            return
+        key_env = self.query_one("#api-key-env", Input).value.strip()
+        cfg = {
+            "provider": provider,
+            "model": self.query_one("#model", Input).value.strip(),
+            "endpoint": self.query_one("#endpoint", Input).value.strip() or None,
+            "api_key": _os.getenv(key_env) if key_env else None,
+        }
+        status.update(Text("Testing connection…", style=Style(color=COLORS["dim"])))
+        self.query_one("#test-conn", Button).disabled = True
+        self.run_worker(self._do_test_connection(cfg), name="conn-test",
+                        group="conn-test", exclusive=True, exit_on_error=False)
+
+    async def _do_test_connection(self, cfg: dict[str, Any]) -> None:
+        from core.init_api import test_llm_connection
+
+        result = await test_llm_connection(cfg)
+        tok = "ok" if result["ok"] else (
+            "warn" if result["status"] in ("rate_limit", "network") else "danger")
+        try:
+            self.query_one("#llm-status", Static).update(
+                Text(result["message"], style=Style(color=COLORS[tok])))
+            self.query_one("#test-conn", Button).disabled = False
+        except Exception:
+            pass
+
     async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "test-conn":
+            self._test_connection()
+            return
         if event.button.id != "next":
             return
         state = _state(self)
@@ -322,13 +635,13 @@ class LLMConfigScreen(Screen):
         state.sub_key_env = state.api_key_env
 
         self._hb_config = {
-            "provider": state.provider,
+            "provider": _persisted_provider(state.provider),
             "model": state.model,
             "endpoint": state.endpoint,
             "api_key_env": state.api_key_env,
         }
         self._sub_config = {
-            "provider": state.sub_provider,
+            "provider": _persisted_provider(state.sub_provider),
             "model": state.sub_model,
             "endpoint": state.sub_endpoint,
             "api_key_env": state.sub_key_env,
@@ -343,7 +656,8 @@ class LLMConfigScreen(Screen):
                                style=Style(color=COLORS["accent"])))
         else:
             status.update(Text("Saving configuration…", style=Style(color=COLORS["dim"])))
-        self.run_worker(self._authorize_and_save(), name="llm-auth", exclusive=True)
+        self.run_worker(self._authorize_and_save(), name="llm-auth",
+                        group="llm-auth", exclusive=True, exit_on_error=False)
 
     async def _authorize_and_save(self) -> None:
         state = _state(self)
@@ -368,7 +682,14 @@ class LLMConfigScreen(Screen):
         if event.worker.name != "llm-auth":
             return
         if event.state == WorkerState.SUCCESS:
-            self.app.switch_screen(ChoosePathScreen())
+            state = _state(self)
+            if getattr(state, "retry_consent", False):
+                # Retrying after a refusal — identity is already saved, so go
+                # straight back to consent with the newly chosen model.
+                state.retry_consent = False
+                self.app.switch_screen(ConsentScreen())
+            else:
+                self.app.switch_screen(ChoosePathScreen())
         elif event.state == WorkerState.ERROR:
             err = event.worker.error
             self.query_one("#next", Button).disabled = False
@@ -761,7 +1082,17 @@ class CustomGoalsScreen(Screen):
 class ConsentScreen(Screen):
     """Run consent flow via LLM and display the result."""
 
-    _countdown: int = 10
+    BINDINGS = [
+        Binding("pageup", "scroll_result('page_up')", "Scroll up", show=False),
+        Binding("pagedown", "scroll_result('page_down')", "Scroll down", show=False),
+    ]
+
+    def action_scroll_result(self, how: str) -> None:
+        try:
+            log = self.query_one("#consent-log", RichLog)
+        except Exception:
+            return
+        (log.scroll_page_up if how == "page_up" else log.scroll_page_down)()
 
     def compose(self) -> ComposeResult:
         yield StepBar(current=3)
@@ -775,12 +1106,20 @@ class ConsentScreen(Screen):
             # markup=False → the agent's reasoning/signature (model output, may
             # contain brackets) is written as Rich Text, never re-parsed.
             yield RichLog(id="consent-log", wrap=True, markup=False)
-        yield Static("", id="consent-countdown")
         with Horizontal(classes="button-bar"):
-            yield Button("Exit Now", id="exit-now", classes="primary", disabled=True)
+            # Shown on consent granted:
+            yield Button("Open Chat (TUI)", id="open-chat", classes="primary")
+            yield Button("Open Web UI", id="open-ui", classes="secondary")
+            # Shown on refusal:
+            yield Button("Change Model & Retry", id="change-model", classes="primary")
+            # Always available once a result is in:
+            yield Button("Exit", id="exit-now", classes="muted", disabled=True)
 
     def on_mount(self) -> None:
         self.query_one("#consent-result").display = False
+        # All action buttons hidden until we have a decision.
+        for bid in ("#open-chat", "#open-ui", "#change-model"):
+            self.query_one(bid).display = False
         self._run_consent()
 
     @staticmethod
@@ -788,7 +1127,12 @@ class ConsentScreen(Screen):
         return "consent-worker"
 
     def _run_consent(self) -> None:
-        self.run_worker(self._do_consent(), name=self._worker_name(), exclusive=True)
+        # exit_on_error=False → a failure surfaces in on_worker_state_changed
+        # instead of crashing the whole wizard.
+        self.run_worker(
+            self._do_consent(), name=self._worker_name(),
+            exclusive=True, exit_on_error=False,
+        )
 
     async def _do_consent(self) -> dict[str, Any]:
         from apps.hexis_init import _load_llm_config_for_consent
@@ -819,7 +1163,14 @@ class ConsentScreen(Screen):
             log = self.query_one("#consent-log", RichLog)
             self.query_one("#consent-loading").display = False
             self.query_one("#consent-result").display = True
-            log.write(f"[red]Consent failed: {event.worker.error}[/red]")
+            log.write(Text(f"Consent failed: {event.worker.error}",
+                           style=Style(color=COLORS["danger"], bold=True)))
+            log.write("")
+            log.write(_plain("Change the model and try again, or exit.", "dim"))
+            change = self.query_one("#change-model", Button)
+            change.display = True
+            change.disabled = False
+            change.focus()
             self.query_one("#exit-now", Button).disabled = False
 
     async def _display_result(self, result: dict[str, Any]) -> None:
@@ -874,7 +1225,6 @@ class ConsentScreen(Screen):
 
         if decision == "consent":
             log.write(Text("Consent granted", style=Style(color=COLORS["ok"], bold=True)))
-            # Show agent name + next steps, then auto-exit
             agent_name = "Hexis"
             conn = _conn(self)
             try:
@@ -887,40 +1237,117 @@ class ConsentScreen(Screen):
             log.write("")
             log.write(Text(f"{agent_name} is ready!", style=Style(color=COLORS["accent"], bold=True)))
             log.write("")
-            log.write(_teal("Next steps:"))
-            log.write(_plain("  hexis chat    \u2014 Say hello"))
-            log.write(_plain("  hexis status  \u2014 Check agent status"))
-            log.write(_plain("  hexis start   \u2014 Enable heartbeat"))
-            self._countdown = 10
-            self._render_countdown()
-            self.query_one("#exit-now", Button).disabled = False
-            self.set_timer(1.0, self._tick_countdown)
-        elif decision == "decline":
-            log.write(Text("Consent declined \u2014 the agent chose not to initialize.",
-                           style=Style(color=COLORS["danger"], bold=True)))
-            self.query_one("#exit-now", Button).disabled = False
+            await self._write_recap(log, state, agent_name)
+            log.write(_teal("How would you like to begin?"))
+            log.write(_plain("  Open Chat (TUI)  \u2014 talk in the terminal"))
+            log.write(_plain("  Open Web UI      \u2014 the browser dashboard"))
+            log.write(_plain("  Exit             \u2014 back to the shell"))
+            log.write("")
+            log.write(_plain("Change anything later with `hexis init`. "
+                             "Enable the autonomous heartbeat with `hexis start`.", "dim"))
+            log.write(_plain("Hexis runs on your machine and sends no telemetry.", "dim"))
+            # No timeout \u2014 the user chooses. Present the next-step buttons.
+            open_chat = self.query_one("#open-chat", Button)
+            open_chat.display = True
+            self.query_one("#open-ui", Button).display = True
+            exit_btn = self.query_one("#exit-now", Button)
+            exit_btn.label = "Exit"
+            exit_btn.disabled = False
+            open_chat.focus()
         else:
-            log.write(Text("Consent abstained.", style=Style(color=COLORS["warn"], bold=True)))
+            # Refusal (decline or abstain): show the FULL exchange so the user
+            # can see whether the prompt was worded poorly, and let them change
+            # the model and retry instead of exiting.
+            if decision == "decline":
+                log.write(Text("Consent declined \u2014 the agent chose not to initialize.",
+                               style=Style(color=COLORS["danger"], bold=True)))
+            else:
+                log.write(Text("Consent abstained.", style=Style(color=COLORS["warn"], bold=True)))
+            log.write("")
+            log.write(_plain(
+                "Full exchange below \u2014 refine services/prompts/consent.md or try "
+                "another model, then use \u201cChange Model & Retry\u201d.", "dim"))
+            log.write("")
+            self._dump_exchange(log, result)
+
+            change = self.query_one("#change-model", Button)
+            change.display = True
+            change.disabled = False
+            change.focus()
             self.query_one("#exit-now", Button).disabled = False
 
-    def _render_countdown(self) -> None:
-        self.query_one("#consent-countdown", Static).update(
-            Text(f"Exiting in {self._countdown}s\u2026  (press Exit Now to leave immediately)",
-                 style=Style(color=COLORS["dim"]))
-        )
+    async def _write_recap(self, log: RichLog, state: Any, agent_name: str) -> None:
+        """Recap what was configured + how many tools are available."""
+        log.write(_teal("What's set up:"))
+        provider = state.provider or "?"
+        log.write(_plain(f"  Identity   {agent_name}"))
+        log.write(_plain(f"  Model      {provider} / {state.model or '?'}"))
+        path_label = {"express": "Express (defaults)",
+                      "character": f"Character{' — ' + state.chosen_card.get('name') if state.chosen_card else ''}",
+                      "custom": "Custom"}.get(state.tier, state.tier or "—")
+        log.write(_plain(f"  Path       {path_label}"))
+        # Tool availability (best-effort; never block the recap on it).
+        try:
+            from core.tools import ToolContext, create_default_registry
+            import asyncpg
+            pool = await asyncpg.create_pool(state.dsn, min_size=1, max_size=2)
+            try:
+                registry = create_default_registry(pool)
+                specs = await registry.get_specs(ToolContext.CHAT)
+                log.write(_plain(f"  Tools      {len(specs)} available in chat"))
+            finally:
+                await pool.close()
+        except Exception:
+            pass
+        log.write("")
 
-    def _tick_countdown(self) -> None:
-        self._countdown -= 1
-        if self._countdown <= 0:
-            self.app.exit(0)
-            return
-        self._render_countdown()  # updates one line in place, no log spam
-        self.set_timer(1.0, self._tick_countdown)
+    def _dump_exchange(self, log: RichLog, result: dict[str, Any]) -> None:
+        """Write the full prompt sent and the raw model response to the log."""
+        log.write(Text("\u2500\u2500 Prompt sent \u2500\u2500",
+                       style=Style(color=COLORS["accent"], bold=True)))
+        for msg in result.get("request_messages", []):
+            role = msg.get("role", "?")
+            content = msg.get("content", "")
+            log.write(Text(f"[{role}]", style=Style(color=COLORS["teal"], bold=True)))
+            log.write(_plain(str(content), "dim"))
+            log.write("")
+
+        log.write(Text("\u2500\u2500 Raw response \u2500\u2500",
+                       style=Style(color=COLORS["accent"], bold=True)))
+        raw_content = (result.get("raw_content") or "").strip()
+        if raw_content:
+            log.write(_plain(raw_content))
+            log.write("")
+        tool_calls = result.get("raw_tool_calls") or []
+        for tc in tool_calls:
+            name = tc.get("name", "?")
+            args = tc.get("arguments", {})
+            if not isinstance(args, str):
+                args = json.dumps(args, indent=2, ensure_ascii=False)
+            log.write(Text(f"tool call \u2192 {name}", style=Style(color=COLORS["teal"])))
+            log.write(_plain(args))
+            log.write("")
+        if not raw_content and not tool_calls:
+            log.write(_plain("(model returned no content and no tool call)", "dim"))
+            log.write("")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "exit-now":
+        bid = event.button.id
+        if bid == "change-model":
+            # Return to model selection; identity stays persisted, so picking a
+            # new model routes straight back here (see InitState.retry_consent).
+            _state(self).retry_consent = True
+            self.app.switch_screen(LLMConfigScreen())
+            return
+        if bid == "open-chat":
+            # Hand off to the chat TUI after init exits (see the CLI init handler).
+            self.app.next_action = "chat"
+            self.app.exit(0)
+            return
+        if bid == "open-ui":
+            self.app.next_action = "ui"
+            self.app.exit(0)
+            return
+        if bid == "exit-now":
             state = _state(self)
-            if state.consent_decision == "consent":
-                self.app.exit(0)
-            else:
-                self.app.exit(1)
+            self.app.exit(0 if state.consent_decision == "consent" else 1)

--- a/apps/tui/init_widgets.py
+++ b/apps/tui/init_widgets.py
@@ -11,7 +11,8 @@ from rich.style import Style
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Horizontal
-from textual.widgets import Label, RichLog, Static
+from textual.widgets import Input, Label, OptionList, RichLog, Static
+from textual.widgets.option_list import Option
 
 from apps.tui.design import COLORS, GLYPHS
 
@@ -158,3 +159,90 @@ class CharacterPreview(Static):
                 line.append(bar, style=Style(color=COLORS["accent"]))
                 line.append(f" {val:.2f}", style=Style(color=COLORS["dim"]))
                 log.write(line)
+
+
+# ── Model combobox (dropdown + free typing) ──────────────────────────────────
+
+class ModelMenu(OptionList):
+    """Inline, filterable dropdown of candidate model ids for ModelCombo."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._all: list[str] = []
+        # Set before a programmatic value fill so the resulting Input.Changed
+        # doesn't immediately re-open the just-dismissed dropdown.
+        self._suppress = False
+
+    def on_mount(self) -> None:
+        self.display = False
+
+    def populate(self, models: list[str]) -> None:
+        self._all = list(models)
+
+    def apply_filter(self, text: str) -> None:
+        needle = (text or "").strip().lower()
+        matches = [m for m in self._all if needle in m.lower()] if needle else list(self._all)
+        matches = matches[:80]
+        self.clear_options()
+        for m in matches:
+            self.add_option(Option(m, id=m))
+        self.display = bool(matches)
+        if matches:
+            self.highlighted = 0
+
+    def hide(self) -> None:
+        self.display = False
+
+    def current(self) -> str | None:
+        if not self.display or self.highlighted is None:
+            return None
+        try:
+            return self.get_option_at_index(self.highlighted).id
+        except Exception:
+            return None
+
+    def move(self, delta: int) -> None:
+        if not self.option_count:
+            return
+        self.highlighted = ((self.highlighted or 0) + delta) % self.option_count
+
+
+class ModelCombo(Input):
+    """Model-name input with an attached ModelMenu dropdown; free-text is fine."""
+
+    def _menu(self) -> "ModelMenu | None":
+        try:
+            return self.screen.query_one("#model-menu", ModelMenu)
+        except Exception:
+            return None
+
+    def on_key(self, event: Any) -> None:
+        menu = self._menu()
+        if menu is None:
+            return
+        if event.key == "escape" and menu.display:
+            menu.hide()
+            event.prevent_default()
+        elif event.key == "down":
+            if not menu.display and menu._all:
+                menu.apply_filter(self.value)
+            else:
+                menu.move(1)
+            event.prevent_default()
+        elif event.key == "up" and menu.display:
+            menu.move(-1)
+            event.prevent_default()
+        elif event.key == "enter" and menu.display:
+            choice = menu.current()
+            if choice:
+                menu._suppress = True
+                self.value = choice
+                self.cursor_position = len(self.value)
+                menu.hide()
+                event.prevent_default()
+                event.stop()
+
+    def on_blur(self) -> None:
+        menu = self._menu()
+        if menu is not None:
+            menu.hide()

--- a/apps/tui/init_widgets.py
+++ b/apps/tui/init_widgets.py
@@ -1,59 +1,97 @@
-"""Custom widgets for the Hexis init wizard TUI."""
+"""Custom widgets for the Hexis init wizard TUI.
+
+All widgets accept ``**kwargs`` and forward them to the base widget, so they can
+be given ``id``/``classes`` (the old ``CharacterPreview(id=…)`` crash class).
+"""
 from __future__ import annotations
 
 from typing import Any
 
+from rich.style import Style
+from rich.text import Text
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
-from textual.reactive import reactive
-from textual.widget import Widget
-from textual.widgets import Input, Label, Static, RichLog
+from textual.containers import Horizontal
+from textual.widgets import Label, RichLog, Static
 
+from apps.tui.design import COLORS, GLYPHS
 
 # ── Step bar ─────────────────────────────────────────────────────────────────
 
-STEPS = ["Models", "Path", "Setup"]
+STEPS = ["Models", "Path", "Setup", "Consent"]
 
 
-class StepBar(Widget):
-    """Progress indicator showing wizard steps: Models > Path > Setup > Consent."""
+class StepBar(Static):
+    """Progress indicator: Models › Path › Setup › Consent."""
 
-    current: reactive[int] = reactive(0)
+    def __init__(self, current: int = 0, **kwargs: Any) -> None:
+        super().__init__("", **kwargs)
+        self._current = current
 
-    def __init__(self, current: int = 0) -> None:
-        super().__init__()
-        self.current = current
+    def on_mount(self) -> None:
+        self.update(self._build())
 
-    def render(self) -> str:
-        parts: list[str] = []
-        for i, label in enumerate(STEPS):
-            if i < self.current:
-                parts.append(f"[green]{label}[/green]")
-            elif i == self.current:
-                parts.append(f"[bold #d8774f]\\[{label}][/bold #d8774f]")
+    def _build(self) -> Text:
+        out = Text(justify="center")
+        for i, name in enumerate(STEPS):
+            if i:
+                out.append(f"  {GLYPHS['chev_closed']}  ", style=Style(color=COLORS["muted"]))
+            if i < self._current:
+                out.append(name, style=Style(color=COLORS["ok"]))
+            elif i == self._current:
+                out.append(name, style=Style(color=COLORS["accent"], bold=True))
             else:
-                parts.append(f"[#4e463d]{label}[/#4e463d]")
-        return " [#4e463d]>[/#4e463d] ".join(parts)
+                out.append(name, style=Style(color=COLORS["muted"]))
+        return out
 
 
-# ── Big Five inputs ──────────────────────────────────────────────────────────
+# ── Big Five sliders ─────────────────────────────────────────────────────────
 
-_TRAIT_NAMES = [
-    "Openness",
-    "Conscientiousness",
-    "Extraversion",
-    "Agreeableness",
-    "Neuroticism",
-]
-
+_TRAIT_NAMES = ["Openness", "Conscientiousness", "Extraversion",
+                "Agreeableness", "Neuroticism"]
 _TRAIT_KEYS = [t.lower() for t in _TRAIT_NAMES]
 
 
-class BigFiveSliders(Widget):
-    """Five personality trait inputs (0.0-1.0)."""
+class TraitSlider(Static):
+    """A focusable 0.0–1.0 slider driven by ←/→ (or h/l)."""
 
-    def __init__(self, defaults: dict[str, float] | None = None) -> None:
-        super().__init__()
+    can_focus = True
+    BAR_WIDTH = 22
+
+    def __init__(self, value: float = 0.5, **kwargs: Any) -> None:
+        super().__init__("", **kwargs)
+        self._value = max(0.0, min(1.0, value))
+
+    def on_mount(self) -> None:
+        self._repaint()
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    def _repaint(self) -> None:
+        filled = int(round(self._value * self.BAR_WIDTH))
+        t = Text()
+        t.append("█" * filled, style=Style(color=COLORS["accent"]))
+        t.append("░" * (self.BAR_WIDTH - filled), style=Style(color=COLORS["muted"]))
+        t.append(f"  {self._value:.2f}", style=Style(color=COLORS["dim"]))
+        self.update(t)
+
+    def on_key(self, event: Any) -> None:
+        if event.key in ("left", "h", "down"):
+            self._value = max(0.0, round(self._value - 0.05, 2))
+            self._repaint()
+            event.prevent_default()
+        elif event.key in ("right", "l", "up"):
+            self._value = min(1.0, round(self._value + 0.05, 2))
+            self._repaint()
+            event.prevent_default()
+
+
+class BigFiveSliders(Static):
+    """Five personality-trait sliders (0.0–1.0)."""
+
+    def __init__(self, defaults: dict[str, float] | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
         self._defaults = defaults or {}
 
     def compose(self) -> ComposeResult:
@@ -61,69 +99,62 @@ class BigFiveSliders(Widget):
             default = self._defaults.get(key, 0.5)
             with Horizontal(classes="big-five-row"):
                 yield Label(f"{name}:", classes="big-five-label")
-                yield Input(
-                    value=f"{default:.2f}",
-                    placeholder="0.0 - 1.0",
-                    id=f"trait-{key}",
-                    classes="big-five-slider",
-                    type="number",
-                )
+                yield TraitSlider(value=default, id=f"trait-{key}")
 
     def get_traits(self) -> dict[str, float]:
         result: dict[str, float] = {}
         for key in _TRAIT_KEYS:
             try:
-                inp = self.query_one(f"#trait-{key}", Input)
-                val = float(inp.value)
-                result[key] = max(0.0, min(1.0, val))
-            except (ValueError, Exception):
+                result[key] = self.query_one(f"#trait-{key}", TraitSlider).value
+            except Exception:
                 result[key] = 0.5
         return result
 
 
 # ── Character preview ────────────────────────────────────────────────────────
 
-class CharacterPreview(Widget):
+class CharacterPreview(Static):
     """Right-side panel showing details of a selected character card."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
 
     def compose(self) -> ComposeResult:
-        yield RichLog(id="preview-log", wrap=True, markup=True, highlight=True)
+        # markup=False → card text (which may contain brackets) is never parsed.
+        yield RichLog(id="preview-log", wrap=True, markup=False)
 
     def update_preview(self, card: dict[str, Any] | None) -> None:
         log = self.query_one("#preview-log", RichLog)
         log.clear()
         if card is None:
-            log.write("[#4e463d]Select a character to preview[/#4e463d]")
+            log.write(Text("Select a character to preview", style=Style(color=COLORS["dim"])))
             return
 
         from core.init_api import get_card_summary
 
         summary = get_card_summary(card)
-        log.write(f"[bold #d8774f]{summary['name']}[/bold #d8774f]")
+        log.write(Text(summary["name"], style=Style(color=COLORS["accent"], bold=True)))
         log.write("")
-        if summary.get("voice"):
-            log.write(f"[#3c6f64]Voice:[/#3c6f64] {summary['voice']}")
-        if summary.get("values"):
-            log.write(f"[#3c6f64]Values:[/#3c6f64] {summary['values']}")
-        if summary.get("personality"):
-            log.write(f"[#3c6f64]Personality:[/#3c6f64] {summary['personality']}")
+        for field in ("voice", "values", "personality"):
+            if summary.get(field):
+                line = Text()
+                line.append(f"{field.capitalize()}: ", style=Style(color=COLORS["teal"]))
+                line.append(str(summary[field]), style=Style(color=COLORS["text"]))
+                log.write(line)
         if summary.get("description"):
             log.write("")
-            log.write(summary["description"])
+            log.write(Text(str(summary["description"]), style=Style(color=COLORS["text"])))
 
-        # Show Big Five bars if available
         ext = card.get("extensions_hexis", {})
         traits = ext.get("personality_traits", {})
         if traits:
             log.write("")
-            log.write("[#3c6f64]Big Five:[/#3c6f64]")
+            log.write(Text("Big Five:", style=Style(color=COLORS["teal"])))
             for trait_name in _TRAIT_NAMES:
-                key = trait_name.lower()
-                val = traits.get(key, 0.5)
-                bar_width = 20
-                filled = int(val * bar_width)
-                bar = "\u2588" * filled + "\u2591" * (bar_width - filled)
-                log.write(f"  {trait_name:20s} [{bar}] {val:.2f}")
+                val = traits.get(trait_name.lower(), 0.5)
+                filled = int(val * 20)
+                bar = "█" * filled + "░" * (20 - filled)
+                line = Text(f"  {trait_name:18s} ", style=Style(color=COLORS["dim"]))
+                line.append(bar, style=Style(color=COLORS["accent"]))
+                line.append(f" {val:.2f}", style=Style(color=COLORS["dim"]))
+                log.write(line)

--- a/apps/tui/model_catalog.py
+++ b/apps/tui/model_catalog.py
@@ -1,0 +1,185 @@
+"""Current per-provider model lists for the init wizard.
+
+Mirrors how hermes-agent / openclaw populate their model pickers: prefer a live,
+auto-updating source over a hand-maintained list, treat it as advisory, and
+always allow a free-typed id.
+
+  * cloud providers → the models.dev catalog (one no-auth JSON covering every
+    provider), cached on disk ~24h and sorted newest-first
+  * ollama → the local daemon's /api/tags (what's actually installed)
+  * on any failure → a short curated fallback; the model field stays free-text
+"""
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+
+import httpx
+
+MODELS_DEV_URL = "https://models.dev/api.json"
+_CACHE = Path.home() / ".cache" / "hexis" / "models_dev.json"
+_CACHE_TTL = 24 * 3600
+_TIMEOUT = 12.0
+
+# Hexis provider id → models.dev slug. Ollama is special-cased (local fetch).
+PROVIDER_SLUG: dict[str, str] = {
+    "openai": "openai",
+    "openai-codex": "openai",
+    "anthropic": "anthropic",
+    "anthropic-oauth": "anthropic",
+    "grok": "xai",
+    "gemini": "google",
+    "chutes": "chutes",
+    "github-copilot": "github-copilot",
+    "qwen-portal": "alibaba",
+    "minimax-portal": "minimax",
+    "google-gemini-cli": "google",
+    "google-antigravity": "google",
+}
+
+# Non-chat model ids to hide from the dropdown (still typeable as free text).
+_NON_CHAT_RE = re.compile(
+    r"embed|tts|whisper|moderation|rerank|image|audio|video|dall.?e|imagen|"
+    r"veo|sora|guard|ocr|speech|transcrib",
+    re.IGNORECASE,
+)
+
+# Minimal offline fallback if models.dev is unreachable.
+_FALLBACK: dict[str, list[str]] = {
+    "openai": ["gpt-5.2", "gpt-4o", "gpt-4o-mini"],
+    "openai-codex": ["gpt-5.2", "gpt-5.2-codex"],
+    "anthropic": ["claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"],
+    "grok": ["grok-4.3", "grok-3"],
+    "gemini": ["gemini-3-pro-preview", "gemini-2.5-flash"],
+    "chutes": ["deepseek-ai/DeepSeek-V3-0324"],
+    "github-copilot": ["gpt-4o"],
+}
+
+_MEM: dict | None = None
+
+
+def _cache_read() -> dict | None:
+    try:
+        if _CACHE.exists() and (time.time() - _CACHE.stat().st_mtime) < _CACHE_TTL:
+            return json.loads(_CACHE.read_text())
+    except Exception:
+        pass
+    return None
+
+
+def _cache_write(data: dict) -> None:
+    try:
+        _CACHE.parent.mkdir(parents=True, exist_ok=True)
+        _CACHE.write_text(json.dumps(data))
+    except Exception:
+        pass
+
+
+async def _models_dev() -> dict:
+    global _MEM
+    if _MEM is not None:
+        return _MEM
+    cached = _cache_read()
+    if cached is not None:
+        _MEM = cached
+        return cached
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.get(MODELS_DEV_URL)
+        resp.raise_for_status()
+        data = resp.json()
+    _cache_write(data)
+    _MEM = data
+    return data
+
+
+def _sort_key(m: dict) -> str:
+    return m.get("last_updated") or m.get("release_date") or ""
+
+
+# Variant/specialty suffixes that shouldn't be the *default* pick (they're still
+# in the list — you can choose them). Keeps the default a sensible flagship.
+_DEFAULT_SKIP = (
+    "-pro", "-mini", "-nano", "-lite", "preview", "-exp", "experimental",
+    "thinking", "chat-latest", "non-reasoning", "multi-agent", "imagine",
+    "-build", "deep-research", "realtime", "-audio", "-tts", "-image",
+    "-high", "-low", "-search", "computer-use",
+)
+
+# Only where "newest non-variant flagship" isn't the right recommendation.
+# Self-healing: ignored if not present in the live catalog.
+_PREFERRED_DEFAULT: dict[str, str] = {
+    "openai-codex": "gpt-5.2-codex",
+}
+
+
+def recommended_default(provider: str, models: list[str]) -> str:
+    """Pick a sensible default model from the *live* catalog (newest-first).
+
+    No provider's default model id is hard-coded (except the tiny self-healing
+    override above). Prefers the newest non-variant flagship; falls back to the
+    newest model; returns "" only if the catalog is empty.
+    """
+    if not models:
+        return ""
+    pref = _PREFERRED_DEFAULT.get(provider)
+    if pref and pref in models:
+        return pref
+    for mid in models:  # models is newest-first
+        if not any(s in mid.lower() for s in _DEFAULT_SKIP):
+            return mid
+    return models[0]
+
+
+def chat_models(provider_block: dict) -> list[str]:
+    """Extract text/chat model ids from a models.dev provider block, newest first."""
+    rows: list[tuple[str, str]] = []
+    for m in provider_block.get("models", {}).values():
+        mid = m.get("id", "")
+        if not mid or _NON_CHAT_RE.search(mid):
+            continue
+        modal = m.get("modalities") or {}
+        outs = modal.get("output") if isinstance(modal, dict) else None
+        if outs and "text" not in outs:
+            continue
+        rows.append((mid, _sort_key(m)))
+    rows.sort(key=lambda t: t[1], reverse=True)
+    seen: set[str] = set()
+    ids: list[str] = []
+    for mid, _ in rows:
+        if mid not in seen:
+            seen.add(mid)
+            ids.append(mid)
+    return ids
+
+
+async def _ollama_models(endpoint: str | None) -> list[str]:
+    host = "http://localhost:11434"
+    if endpoint:
+        m = re.match(r"(https?://[^/]+)", endpoint.strip())
+        if m:
+            host = m.group(1)
+    url = host.rstrip("/") + "/api/tags"
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+    return [m["name"] for m in data.get("models", []) if m.get("name")]
+
+
+async def fetch_models(provider: str, *, endpoint: str | None = None) -> list[str]:
+    """Best-effort current chat model ids for *provider* (newest first)."""
+    try:
+        if provider == "ollama":
+            return await _ollama_models(endpoint)
+        slug = PROVIDER_SLUG.get(provider)
+        if not slug:
+            return _FALLBACK.get(provider, [])
+        data = await _models_dev()
+        block = data.get(slug)
+        if not block:
+            return _FALLBACK.get(provider, [])
+        return chat_models(block) or _FALLBACK.get(provider, [])
+    except Exception:
+        return _FALLBACK.get(provider, [])

--- a/apps/tui/status_bar.py
+++ b/apps/tui/status_bar.py
@@ -1,0 +1,154 @@
+"""Progressive-disclosure status bar for the chat screen.
+
+One line that pins the busy indicator + model on the left and sheds tail
+segments (energy, tools, mood, context) in priority order as the terminal
+narrows — instead of truncating mid-segment. Owns its own 1s tick so callers
+just push state via ``set_busy`` / ``set_idle`` / ``update``.
+"""
+from __future__ import annotations
+
+from time import monotonic
+
+from rich.style import Style
+from rich.text import Text
+from textual.widgets import Static
+
+from apps.tui import textkit
+from apps.tui.design import COLORS, GLYPHS
+
+
+class StatusBar(Static):
+    """A single-line, width-aware status readout."""
+
+    DEFAULT_CSS = """
+    StatusBar {
+        height: 1;
+        background: $surface;
+        color: $foreground;
+    }
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__("", **kwargs)
+        self._busy = False
+        self._label = ""
+        self._model = ""
+        self._energy: int | None = None
+        self._max_energy: int | None = None
+        self._tools = 0
+        self._mood = ""
+        self._ctx_pct: float | None = None
+        self._started: float | None = None
+        self._idle_at: float | None = None
+        self._tick = 0
+        self._width = 80
+
+    def on_mount(self) -> None:
+        self.set_interval(1.0, self._on_tick)
+        # First paint must wait until after layout — reading self.size mid-mount
+        # re-enters layout and deadlocks.
+        self.call_after_refresh(self._repaint)
+
+    def on_resize(self, event) -> None:
+        self._width = event.size.width or 80
+        self._repaint()
+
+    def _on_tick(self) -> None:
+        self._tick += 1
+        self._repaint()
+
+    # ── state in ────────────────────────────────────────────────────────────
+    def set_busy(self, label: str = "") -> None:
+        if not self._busy or self._started is None:
+            self._started = monotonic()
+        self._busy = True
+        self._label = label
+        self._idle_at = None
+        self._repaint()
+
+    def set_idle(self) -> None:
+        if self._busy:
+            self._idle_at = monotonic()
+        self._busy = False
+        self._label = ""
+        self._started = None
+        self._repaint()
+
+    def update_state(
+        self,
+        *,
+        model: str | None = None,
+        energy: int | None = None,
+        max_energy: int | None = None,
+        tools: int | None = None,
+        mood: str | None = None,
+        context: float | None = None,
+    ) -> None:
+        if model is not None:
+            self._model = model
+        if energy is not None:
+            self._energy = energy
+        if max_energy is not None:
+            self._max_energy = max_energy
+        if tools is not None:
+            self._tools = tools
+        if mood is not None:
+            self._mood = mood
+        if context is not None:
+            self._ctx_pct = context
+        self._repaint()
+
+    # kept as an alias so callers can use the familiar name
+    update_status = update_state
+
+    # ── render ──────────────────────────────────────────────────────────────
+    def _lead(self) -> Text:
+        t = Text(" ", no_wrap=True)
+        if self._busy:
+            verb = self._label or textkit.rotating(textkit.THINK_VERBS, self._tick // 3)
+            t.append(f"{verb}… ", style=Style(color=COLORS["accent"], bold=True))
+            if self._started is not None:
+                t.append(textkit.format_elapsed(monotonic() - self._started),
+                         style=Style(color=COLORS["dim"]))
+        else:
+            if self._idle_at is not None:
+                t.append(f"{GLYPHS['ok']} ", style=Style(color=COLORS["ok"]))
+                t.append(textkit.format_elapsed(monotonic() - self._idle_at),
+                         style=Style(color=COLORS["dim"]))
+            else:
+                t.append("ready", style=Style(color=COLORS["dim"]))
+        return t
+
+    def _segments(self) -> list[Text]:
+        """Tail segments in *descending* priority (first survives longest)."""
+        segs: list[Text] = []
+        if self._model:
+            segs.append(Text(self._model, style=Style(color=COLORS["dim"])))
+        if self._energy is not None and self._max_energy:
+            e = Text()
+            e.append(GLYPHS["energy"], style=Style(color=COLORS["accent"]))
+            ratio = self._energy / self._max_energy if self._max_energy else 0
+            tok = "ok" if ratio > 0.5 else "warn" if ratio > 0.25 else "danger"
+            e.append(f"{self._energy}/{self._max_energy}", style=Style(color=COLORS[tok]))
+            segs.append(e)
+        if self._tools:
+            segs.append(Text(f"⚙ {self._tools}", style=Style(color=COLORS["teal"])))
+        if self._mood:
+            segs.append(Text(self._mood, style=Style(color=COLORS["teal"])))
+        if self._ctx_pct is not None:
+            segs.append(Text(f"ctx {self._ctx_pct:.0f}%", style=Style(color=COLORS["dim"])))
+        return segs
+
+    def _build(self) -> Text:
+        width = self._width
+        sep = Text(f" {GLYPHS['sep']} ", style=Style(color=COLORS["muted"]))
+        out = self._lead()
+        for seg in self._segments():
+            if out.cell_len + sep.cell_len + seg.cell_len + 1 > width:
+                break
+            out.append_text(sep)
+            out.append_text(seg)
+        return out
+
+    def _repaint(self) -> None:
+        self.update(self._build())

--- a/apps/tui/textkit.py
+++ b/apps/tui/textkit.py
@@ -1,0 +1,175 @@
+"""Pure text helpers for the Hexis TUI — no Textual imports, easy to unit-test.
+
+Covers:
+  * ``strip_scaffolding`` — remove leaked model scaffolding (<think>, tool-call
+    blocks, special tokens, trace lines) from visible text, capturing the
+    reasoning separately. Code-fence-aware and streaming-safe (partial/unclosed
+    tags are held back rather than flashed).
+  * ``redact`` — mask secrets and home paths before showing tool output.
+  * ``format_elapsed`` / ``truncate`` — small formatters.
+  * content pools (think-verbs, placeholders) + ``rotating``.
+"""
+from __future__ import annotations
+
+import re
+
+# ── Scaffolding strip ────────────────────────────────────────────────────────
+
+_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_THINK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
+_THINK_OPEN_RE = re.compile(r"<think>(.*)$", re.DOTALL | re.IGNORECASE)
+
+_TOOLCALL_RES = [
+    re.compile(r"<tool_call>.*?</tool_call>", re.DOTALL | re.IGNORECASE),
+    re.compile(r"<function_calls>.*?</function_calls>", re.DOTALL | re.IGNORECASE),
+    re.compile(r"<invoke\b.*?</invoke>", re.DOTALL | re.IGNORECASE),
+    re.compile(r"</?antml:[^>]*>", re.IGNORECASE),
+    re.compile(r"\[TOOL_CALL\].*?\[/TOOL_CALL\]", re.DOTALL | re.IGNORECASE),
+]
+
+# Model special tokens: <|im_start|>, <|channel|>, <|end|>, <s>, </s>, …
+_SPECIAL_TOKEN_RE = re.compile(r"<\|[^|>]*\|>|</?s>", re.IGNORECASE)
+
+# Internal trace lines the runtime sometimes prints (emoji-prefixed). Kept
+# conservative: only lines that clearly look like tool/session traces.
+_TRACE_LINE_RE = re.compile(
+    r"^[ \t]*(?:\U0001F4CA|\U0001F6E0️?|\U0001F4D6|⚙️?|\U0001F527|\U0001F9E9)"
+    r"[ \t]*(?:Session Status|Exec|Read|Tool Call|Tool)\b.*$",
+    re.MULTILINE,
+)
+
+# A dangling partial tag at the very end of a stream chunk (e.g. "<", "<th",
+# "<tool_ca"). Hold it back so it never flashes; the next chunk completes it.
+_DANGLING_TAG_RE = re.compile(r"<[a-zA-Z|/!\[]*$")
+
+_FENCE_STASH_RE = re.compile("\x00F(\\d+)\x00")
+
+
+def strip_scaffolding(text: str) -> tuple[str, str]:
+    """Split *text* into (visible, reasoning).
+
+    ``visible`` is the user-facing prose with all scaffolding removed.
+    ``reasoning`` is any captured ``<think>`` content (may be empty).
+    Safe to call repeatedly on the growing buffer of a streaming response.
+    """
+    if not text:
+        return "", ""
+
+    # 1. Protect complete fenced code blocks so we never strip inside them.
+    fences: list[str] = []
+
+    def _stash(m: re.Match[str]) -> str:
+        fences.append(m.group(0))
+        return f"\x00F{len(fences) - 1}\x00"
+
+    work = _FENCE_RE.sub(_stash, text)
+
+    reasoning: list[str] = []
+
+    # 2. Complete <think>…</think> blocks → reasoning.
+    def _grab(m: re.Match[str]) -> str:
+        chunk = m.group(1).strip()
+        if chunk:
+            reasoning.append(chunk)
+        return ""
+
+    work = _THINK_RE.sub(_grab, work)
+
+    # 3. Unclosed <think> (still streaming): everything after it is reasoning.
+    m = _THINK_OPEN_RE.search(work)
+    if m:
+        tail = m.group(1).strip()
+        if tail:
+            reasoning.append(tail)
+        work = work[: m.start()]
+
+    # 4. Tool-call blocks + special tokens + trace lines.
+    for rx in _TOOLCALL_RES:
+        work = rx.sub("", work)
+    work = _SPECIAL_TOKEN_RE.sub("", work)
+    work = _TRACE_LINE_RE.sub("", work)
+
+    # 5. Trim a trailing partial tag fragment (streaming edge).
+    work = _DANGLING_TAG_RE.sub("", work)
+
+    # 6. Restore protected fences.
+    def _restore(m: re.Match[str]) -> str:
+        return fences[int(m.group(1))]
+
+    visible = _FENCE_STASH_RE.sub(_restore, work)
+
+    # Tidy: collapse 3+ blank lines the strips may have left behind.
+    visible = re.sub(r"\n{3,}", "\n\n", visible)
+    return visible, "\n".join(reasoning)
+
+
+# ── Redaction ────────────────────────────────────────────────────────────────
+
+import os as _os
+
+_HOME = _os.path.expanduser("~")
+
+_SECRET_RES = [
+    (re.compile(r"(Authorization\s*:\s*)\S+", re.IGNORECASE), r"\1[redacted]"),
+    (re.compile(r"(Cookie\s*:\s*)\S+", re.IGNORECASE), r"\1[redacted]"),
+    (re.compile(r"\bBearer\s+[A-Za-z0-9._\-]+", re.IGNORECASE), "Bearer [redacted]"),
+    (re.compile(r"\b(sk|xai|ghp|gho|pk)-[A-Za-z0-9\-_]{8,}"), "[redacted-key]"),
+    (re.compile(r"((?:api[_-]?key|token|password|secret)\s*[=:]\s*)['\"]?[^\s'\"]+",
+                re.IGNORECASE), r"\1[redacted]"),
+    (re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----.*?-----END [A-Z ]+PRIVATE KEY-----",
+                re.DOTALL), "[redacted-private-key]"),
+]
+
+
+def redact(text: str) -> str:
+    """Mask secrets and shorten the user's home path before display."""
+    if not text:
+        return text
+    for rx, repl in _SECRET_RES:
+        text = rx.sub(repl, text)
+    if _HOME and _HOME != "/":
+        text = text.replace(_HOME, "~")
+    return text
+
+
+# ── Formatters ───────────────────────────────────────────────────────────────
+
+def format_elapsed(seconds: float) -> str:
+    """Human elapsed: ``8s`` / ``2m 13s`` / ``1h 04m``."""
+    total = max(0, int(seconds))
+    if total < 60:
+        return f"{total}s"
+    if total < 3600:
+        m, s = divmod(total, 60)
+        return f"{m}m {s:02d}s"
+    h, rem = divmod(total, 3600)
+    m = rem // 60
+    return f"{h}h {m:02d}m"
+
+
+def truncate(text: str, limit: int, ellipsis: str = "…") -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - len(ellipsis))].rstrip() + ellipsis
+
+
+def rotating(seq: list[str], i: int) -> str:
+    """Cycle through *seq* by index (jitter-free, deterministic)."""
+    return seq[i % len(seq)] if seq else ""
+
+
+# ── Content pools ────────────────────────────────────────────────────────────
+
+THINK_VERBS = [
+    "pondering", "contemplating", "musing", "reasoning", "reflecting",
+    "considering", "synthesizing", "weighing", "recollecting", "deliberating",
+]
+
+PLACEHOLDERS = [
+    "Ask me anything…",
+    "Try \"what do you remember about…\"",
+    "Type / for commands",
+    "Try \"/recall <topic>\"",
+    "Type your message…",
+]

--- a/apps/tui/theme.py
+++ b/apps/tui/theme.py
@@ -1,29 +1,12 @@
-"""Hexis Textual theme — color tokens matching cli_theme.py / hexis-ui CSS."""
+"""Hexis Textual theme — kept as a thin re-export of :mod:`apps.tui.design`.
+
+The palette and theme now live in ``design.py`` (single source of truth). This
+module remains so existing imports (``from apps.tui.theme import hexis_theme``)
+keep working.
+"""
 from __future__ import annotations
 
-from textual.design import ColorSystem
-from textual.theme import Theme
+from apps.tui.design import COLORS as HEXIS_COLORS
+from apps.tui.design import CSS_VARS, hexis_theme
 
-HEXIS_COLORS = {
-    "accent": "#d8774f",
-    "accent_strong": "#b45835",
-    "teal": "#3c6f64",
-    "muted": "#4e463d",
-    "bg": "#1a1a1a",
-    "surface": "#242424",
-    "text": "#e0d8d0",
-}
-
-hexis_theme = Theme(
-    name="hexis",
-    primary=HEXIS_COLORS["accent"],
-    secondary=HEXIS_COLORS["teal"],
-    accent=HEXIS_COLORS["accent_strong"],
-    background=HEXIS_COLORS["bg"],
-    surface=HEXIS_COLORS["surface"],
-    foreground=HEXIS_COLORS["text"],
-    success="#4a9",
-    warning="#da3",
-    error="#c44",
-    dark=True,
-)
+__all__ = ["hexis_theme", "HEXIS_COLORS", "CSS_VARS"]

--- a/apps/tui/tips.py
+++ b/apps/tui/tips.py
@@ -1,0 +1,49 @@
+"""Ambient feature-discovery tips shown at chat startup.
+
+Mirrors hermes-agent's tips corpus / openclaw's "what now" hints: a rotating
+one-liner surfaces a feature the user might not have discovered, without a
+blocking tutorial.
+"""
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+# Show-once flags persisted locally (survive DB resets; no round-trip).
+_SEEN_PATH = Path.home() / ".hexis" / "onboarding_seen.json"
+
+
+def seen(flag: str) -> bool:
+    try:
+        return bool(json.loads(_SEEN_PATH.read_text()).get(flag))
+    except Exception:
+        return False
+
+
+def mark_seen(flag: str) -> None:
+    try:
+        _SEEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        data = json.loads(_SEEN_PATH.read_text()) if _SEEN_PATH.exists() else {}
+        data[flag] = True
+        _SEEN_PATH.write_text(json.dumps(data))
+    except Exception:
+        pass
+
+# Kept surface-agnostic: every tip is true in both the line-based CLI and the
+# (legacy) Textual TUI. Don't add TUI-only keybindings (Ctrl+T, PageUp) here —
+# the CLI REPL surfaces these too and must not advertise controls it lacks.
+TIPS: list[str] = [
+    "Type /help to see commands — try /recall <topic> to search memories.",
+    "Ctrl+C interrupts a running reply; press it again (or /quit) to exit.",
+    "/status shows energy, mood, and consent at a glance.",
+    "/tools lists everything the agent can do right now.",
+    "The agent remembers across sessions; it forms memories after each turn.",
+    "Run `hexis start` to enable the autonomous heartbeat.",
+    "Run `hexis doctor --llm` to verify your model connection.",
+    "Re-run `hexis init` any time to reconfigure — it won't wipe anything unasked.",
+]
+
+
+def random_tip() -> str:
+    return "Tip: " + random.choice(TIPS)

--- a/core/auth/anthropic_oauth.py
+++ b/core/auth/anthropic_oauth.py
@@ -320,61 +320,39 @@ async def _refresh_claude_code_token(creds: dict[str, Any]) -> str | None:
 # ---------------------------------------------------------------------------
 
 async def resolve_anthropic_token() -> tuple[str | None, str]:
-    """Resolve an Anthropic token from all available sources.
+    """Resolve an Anthropic OAuth/subscription token from Hexis's OWN store only.
 
-    Returns (token, auth_mode) where auth_mode is one of:
-    - "oauth" for OAuth tokens (setup-token or PKCE)
-    - "setup-token" for setup tokens
-    - "api-key" for regular API keys
-    - "" if nothing found
+    Hexis manages its own Anthropic login and deliberately does **not** read
+    Claude Code's credentials (``~/.claude/.credentials.json`` / the macOS
+    Keychain) or environment tokens. Populate the store with one of:
+        hexis auth anthropic login          # OAuth PKCE (Claude Pro/Max)
+        hexis auth anthropic setup-token     # paste a setup token
 
-    Priority:
-    1. Hexis-native PKCE OAuth (~/.hexis/auth/)
-    2. Claude Code credentials (~/.claude/.credentials.json or macOS Keychain)
-    3. CLAUDE_CODE_OAUTH_TOKEN env var
-    4. Anthropic setup token (~/.hexis/auth/)
-    5. ANTHROPIC_API_KEY env var
+    Returns (token, auth_mode): auth_mode is "setup-token" for a stored
+    OAuth/subscription token, or "" if nothing is stored.
+
+    Note: plain API-key auth for ``provider=anthropic`` is handled separately by
+    ``normalize_llm_config`` (via ``api_key_env`` / the ``ANTHROPIC_API_KEY``
+    env var) and does not go through this function.
     """
-    # 1. Hexis-native PKCE OAuth
+    # 1. Hexis-native PKCE OAuth (~/.hexis/auth/oauth.anthropic.json)
     hexis_creds = load_credentials()
     if hexis_creds:
         if not needs_refresh(hexis_creds.expires_ms, 120):
             return hexis_creds.access, "setup-token"
-        # Try to refresh
+        # Token is near expiry — refresh it in place.
         try:
             refreshed = await refresh_anthropic_token(hexis_creds.refresh)
             save_credentials(refreshed)
             return refreshed.access, "setup-token"
         except Exception as exc:
-            logger.debug("Hexis Anthropic token expired and refresh failed: %s", exc)
+            logger.debug("Hexis Anthropic OAuth token expired and refresh failed: %s", exc)
 
-    # 2. Claude Code credentials
-    cc_creds = read_claude_code_credentials()
-    if cc_creds:
-        access = cc_creds.get("accessToken", "")
-        if _is_claude_code_token_valid(cc_creds):
-            return access, "setup-token"
-        refreshed_token = await _refresh_claude_code_token(cc_creds)
-        if refreshed_token:
-            return refreshed_token, "setup-token"
-
-    # 3. CLAUDE_CODE_OAUTH_TOKEN env var
-    cc_env = os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
-    if cc_env:
-        return cc_env, "setup-token"
-
-    # 4. Anthropic setup token
+    # 2. Hexis-stored setup token (~/.hexis/auth/token.anthropic_setup_token.json)
     from core.auth.anthropic_setup_token import load_credentials as load_setup_token
     setup_creds = load_setup_token()
     if setup_creds:
         return setup_creds.token, "setup-token"
-
-    # 5. ANTHROPIC_API_KEY env var
-    api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
-    if api_key:
-        if is_oauth_token(api_key):
-            return api_key, "setup-token"
-        return api_key, "api-key"
 
     return None, ""
 

--- a/core/cli_api.py
+++ b/core/cli_api.py
@@ -14,14 +14,15 @@ from core.cognitive_memory_api import CognitiveMemory, MemoryType
 logger = logging.getLogger(__name__)
 
 
-def embedding_service_diagnosis(url: str | None) -> tuple[str, list[str]]:
+def embedding_service_diagnosis(url: str | None, model: str | None = None) -> tuple[str, list[str]]:
     """Identify the embedding backend from its URL and return (name, fix_steps)."""
     url = (url or "").lower()
+    emb_model = model or "embeddinggemma:300m-qat-q4_0"
     if ":11434" in url:
         return "Ollama", [
             "Install Ollama — https://ollama.com/download",
             "Start it:       ollama serve",
-            "Pull the model:  ollama pull embeddinggemma:300m-qat-q4_0",
+            f"Pull the model:  ollama pull {emb_model}",
         ]
     if "embeddings:" in url or "text-embeddings" in url:
         return "TEI (Text Embeddings Inference)", [
@@ -248,13 +249,22 @@ async def demo(dsn: str | None = None, *, wait_seconds: int = 30) -> dict[str, A
         hydrate = await mem.hydrate("Summarize what we know about the user", include_goals=False)
         working_hits = await mem.search_working("temporary context", limit=5)
 
-        return {
-            "remembered_ids": [str(m1), str(m2)],
-            "working_memory_id": str(held),
-            "recall_count": len(recall.memories),
-            "hydrate_memory_count": len(hydrate.memories),
-            "working_search_count": len(working_hits),
-        }
+    # A health check must not leave demo rows in the agent's real memory (Bar #5).
+    # The working-memory entry auto-expires via its TTL; delete the persistent ones.
+    cleanup = await _connect_with_retry(dsn, wait_seconds=wait_seconds)
+    try:
+        await cleanup.execute("DELETE FROM memories WHERE id = ANY($1::uuid[])", [m1, m2])
+    finally:
+        await cleanup.close()
+
+    return {
+        "remembered_ids": [str(m1), str(m2)],
+        "cleaned_up": True,
+        "working_memory_id": str(held),
+        "recall_count": len(recall.memories),
+        "hydrate_memory_count": len(hydrate.memories),
+        "working_search_count": len(working_hits),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -281,11 +291,15 @@ async def doctor_payload(
     dsn: str | None = None,
     *,
     wait_seconds: int = 10,
+    check_llm: bool = False,
 ) -> list[dict[str, Any]]:
     """
     Run comprehensive health checks and return a list of check results.
 
     Each result: {"label": str, "status": "OK"|"WARN"|"FAIL", "detail": Any}
+
+    ``check_llm`` opt-in makes one real LLM call to verify provider/model/key
+    (skipped by default so a health check never silently spends a token).
     """
     dsn = dsn or db_dsn_from_env()
     checks: list[dict[str, Any]] = []
@@ -294,7 +308,12 @@ async def doctor_payload(
     try:
         conn = await _connect_with_retry(dsn, wait_seconds=wait_seconds)
     except Exception as exc:
-        checks.append({"label": "PostgreSQL", "status": "FAIL", "detail": str(exc)})
+        low = str(exc).lower()
+        if any(s in low for s in ("connect", "refused", "timed out", "timeout")):
+            detail = "database not reachable — is the stack running? Run `hexis up`, then retry."
+        else:
+            detail = str(exc)
+        checks.append({"label": "PostgreSQL", "status": "FAIL", "detail": detail})
         return checks  # Can't do anything else without DB
 
     try:
@@ -317,7 +336,7 @@ async def doctor_payload(
                     "detail": f"healthy — {emb_model} via {emb_url}",
                 })
             else:
-                svc_name, steps = embedding_service_diagnosis(emb_url)
+                svc_name, steps = embedding_service_diagnosis(emb_url, emb_model)
                 fix = "; ".join(steps)
                 checks.append({
                     "label": "Embeddings",
@@ -542,6 +561,28 @@ async def doctor_payload(
                 })
         except Exception as exc:
             checks.append({"label": "Memory", "status": "FAIL", "detail": str(exc)})
+
+        # 12. LLM connectivity (opt-in: makes one real call)
+        if check_llm:
+            try:
+                from core.init_api import test_llm_connection
+                from core.llm_config import load_llm_config
+                llm_config = await load_llm_config(conn, "llm.chat", fallback_key="llm")
+                result = await test_llm_connection(llm_config)
+                model = f"{llm_config.get('provider', '?')}/{llm_config.get('model', '?')}"
+                checks.append({
+                    "label": "LLM",
+                    "status": "OK" if result["ok"] else "FAIL",
+                    "detail": f"{model} — {result['message']}",
+                })
+            except Exception as exc:
+                checks.append({"label": "LLM", "status": "FAIL", "detail": str(exc)})
+        else:
+            checks.append({
+                "label": "LLM",
+                "status": "WARN",
+                "detail": "not tested (run 'hexis doctor --llm' for a live connectivity check)",
+            })
 
     finally:
         await conn.close()

--- a/core/init_api.py
+++ b/core/init_api.py
@@ -18,6 +18,68 @@ USER_CHARACTERS_DIR = Path.home() / ".hexis" / "characters"
 CHARACTERS_DIR = PACKAGE_CHARACTERS_DIR
 
 
+# ---------------------------------------------------------------------------
+# LLM connectivity self-test (advisory — never blocks setup)
+# ---------------------------------------------------------------------------
+# Both hermes-agent and openclaw learned the hard way that hard-blocking setup
+# on a live key probe rejects too many legitimate users (corporate proxies,
+# regional blocks, flaky provider probes, self-hosted endpoints). So this is an
+# opt-in / advisory check that translates errors into clear guidance and never
+# prevents the user from proceeding.
+
+def classify_llm_error(msg: str) -> tuple[str, str]:
+    """Map a raw provider error into (status_slug, human_message)."""
+    low = msg.lower()
+    if any(s in msg for s in ("401", "403")) or any(
+        s in low for s in ("unauthorized", "invalid api key", "invalid x-api-key",
+                            "authentication", "invalid_api_key", "permission")):
+        return "auth", "Authentication failed — the API key/login looks invalid or missing."
+    if "402" in msg or any(s in low for s in ("payment required", "insufficient",
+                                              "out of credit", "quota", "billing", "balance")):
+        return "billing", "Out of credits / payment required for this account."
+    if "429" in msg or any(s in low for s in ("rate limit", "too many requests", "overloaded")):
+        return "rate_limit", "Rate limited — the provider is throttling; try again shortly."
+    if "404" in msg or any(s in low for s in ("not found", "does not exist", "no such model",
+                                              "unknown model", "model_not_found")):
+        return "model", "Model or endpoint not found — check the model name and endpoint."
+    if any(s in low for s in ("timeout", "timed out", "connection", "getaddrinfo",
+                              "network", "refused", "unreachable", "ssl", "certificate")):
+        return "network", "Network error — could not reach the provider endpoint."
+    return "error", f"Request failed: {msg[:200]}"
+
+
+async def test_llm_connection(llm_config: dict[str, Any]) -> dict[str, Any]:
+    """Make one tiny real call to verify the provider/model/credentials work.
+
+    Returns {"ok": bool, "status": str, "message": str}. Never raises.
+    """
+    from core.llm import chat_completion
+
+    provider = llm_config.get("provider") or ""
+    model = llm_config.get("model") or ""
+    if not provider or not model:
+        return {"ok": False, "status": "config",
+                "message": "No provider/model configured."}
+    try:
+        result = await chat_completion(
+            provider=provider,
+            model=model,
+            endpoint=llm_config.get("endpoint"),
+            api_key=llm_config.get("api_key"),
+            auth_mode=llm_config.get("auth_mode"),
+            messages=[{"role": "user", "content": "Reply with just the word: ok"}],
+            tools=None,
+            temperature=0.0,
+            max_tokens=16,
+        )
+        content = (result.get("content") or "").strip()
+        detail = f'model replied "{content[:40]}"' if content else "model reachable"
+        return {"ok": True, "status": "ok", "message": f"Connected — {detail}."}
+    except Exception as exc:  # noqa: BLE001 — advisory, translate everything
+        status, human = classify_llm_error(str(exc))
+        return {"ok": False, "status": status, "message": human}
+
+
 def _character_search_dirs() -> list[Path]:
     """Return character directories in priority order (first wins on filename collision)."""
     dirs: list[Path] = []
@@ -209,12 +271,15 @@ async def run_consent_flow(
         },
     }
 
-    # Call LLM
+    # Call LLM. Pass auth_mode so OAuth/setup-token providers (e.g. Anthropic
+    # via Claude Pro/Max) route to the Bearer HTTP client instead of the SDK
+    # api-key path.
     result = await chat_completion(
         provider=llm_config["provider"],
         model=llm_config["model"],
         endpoint=llm_config.get("endpoint"),
         api_key=llm_config.get("api_key"),
+        auth_mode=llm_config.get("auth_mode"),
         messages=messages,
         tools=[sign_consent_tool],
         temperature=0.2,
@@ -241,7 +306,20 @@ async def run_consent_flow(
                 except json.JSONDecodeError:
                     pass
 
+    # Lenient fallback: a weak model may state its decision in prose without a
+    # valid tool call / JSON. Accept only explicit phrasings.
+    if not args.get("decision"):
+        low = (result.get("content") or "").lower()
+        if any(p in low for p in ("i decline", "do not consent", "don't consent", "i refuse")):
+            args["decision"] = "decline"
+        elif any(p in low for p in ("i consent", "i agree to", "i hereby consent")):
+            args["decision"] = "consent"
+
+    # Whether the model actually expressed a decision (vs. failing to produce one).
+    decided = bool(args.get("decision"))
     decision = str(args.get("decision", "abstain")).lower().strip()
+    if decision not in ("consent", "decline", "abstain"):
+        decision = "abstain"
     signature = args.get("signature")
     memories = args.get("memories", [])
 
@@ -281,6 +359,7 @@ async def run_consent_flow(
 
     return {
         "decision": consent_result.get("decision", decision),
+        "decided": decided,
         "signature": signature,
         "consent": consent_result,
         "request_messages": messages,
@@ -288,3 +367,43 @@ async def run_consent_flow(
         "raw_content": result.get("content", ""),
         "raw_tool_calls": result.get("tool_calls", []),
     }
+
+
+async def record_consent_override(pool_or_conn, llm_config: dict, *, model_decision: str) -> dict:
+    """Activate the agent by operator override.
+
+    Consent is a signal that Hexis takes the agent seriously — not a lock that can
+    trap the owner out of their own (paid-for) AI. When the model doesn't consent,
+    the owner may choose to proceed anyway; this records that choice honestly (the
+    model's response is preserved in the signature) and activates the agent.
+    """
+    payload = {
+        "decision": "consent",
+        "signature": (
+            f"Operator override: the owner chose to proceed after the model responded "
+            f"'{model_decision}'. Consent here is a signal, not a gate — it's the owner's agent."
+        ),
+        "memories": [],
+        "provider": llm_config["provider"],
+        "model": llm_config["model"],
+        "endpoint": llm_config.get("endpoint"),
+        "consent_scope": "conscious",
+        "apply_agent_config": True,
+        "operator_override": True,
+    }
+    conn = pool_or_conn
+    needs_release = False
+    if hasattr(pool_or_conn, "acquire"):
+        conn = await pool_or_conn.acquire()
+        needs_release = True
+    try:
+        raw = await conn.fetchval("SELECT init_consent($1::jsonb)", json.dumps(payload))
+        if isinstance(raw, str):
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return {"decision": "consent"}
+        return raw if isinstance(raw, dict) else {"decision": "consent"}
+    finally:
+        if needs_release:
+            await pool_or_conn.release(conn)

--- a/core/providers/anthropic_http.py
+++ b/core/providers/anthropic_http.py
@@ -23,10 +23,10 @@ import httpx
 _ANTHROPIC_VERSION = "2023-06-01"
 _ANTHROPIC_BETA = "claude-code-20250219,oauth-2025-04-20"
 _CLAUDE_CODE_USER_AGENT = "claude-cli/2.1.2 (external, cli)"
-_CLAUDE_CODE_IDENTITY = (
-    "You are Claude Code, made by Anthropic. "
-    "You are an interactive agent that helps users with software engineering tasks."
-)
+# Must be verbatim: Anthropic's subscription (OAuth) endpoint validates the
+# Claude-Code identity preamble. hermes-agent and openclaw both send this exact
+# string; a different wording can 401.
+_CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude."
 
 
 # ---------------------------------------------------------------------------
@@ -51,15 +51,48 @@ def _build_headers(api_key: str, auth_mode: str) -> dict[str, str]:
     }
 
 
-def _convert_tools(tools: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+def _oauth_tool_name(name: str) -> str:
+    """Normalize a tool name for the OAuth/subscription path.
+
+    Anthropic's subscription billing classifier flags single-underscore
+    ``mcp_`` tool names as third-party apps and 400s the request; Claude Code
+    uses a double underscore (``mcp__``). Hexis emits ``mcp_<server>_<tool>``
+    (see core/tools/mcp.py), so rewrite those. Matches hermes-agent.
+    """
+    if name.startswith("mcp_") and not name.startswith("mcp__"):
+        return "mcp__" + name[len("mcp_"):]
+    return name
+
+
+def _tool_name_restore_map(
+    tools: list[dict[str, Any]] | None, auth_mode: str
+) -> dict[str, str]:
+    """Map wire (on-the-wire) tool names back to originals for the OAuth path."""
+    if auth_mode != "setup-token" or not tools:
+        return {}
+    restore: dict[str, str] = {}
+    for tool in tools:
+        orig = (tool.get("function") or {}).get("name", "")
+        wire = _oauth_tool_name(orig)
+        if wire != orig:
+            restore[wire] = orig
+    return restore
+
+
+def _convert_tools(
+    tools: list[dict[str, Any]] | None, auth_mode: str = "api-key"
+) -> list[dict[str, Any]]:
     """Convert OpenAI-format tools to Anthropic Messages tool format."""
     if not tools:
         return []
     result: list[dict[str, Any]] = []
     for tool in tools:
         fn = tool.get("function", {})
+        name = fn.get("name", "")
+        if auth_mode == "setup-token":
+            name = _oauth_tool_name(name)
         result.append({
-            "name": fn.get("name", ""),
+            "name": name,
             "description": fn.get("description", ""),
             "input_schema": fn.get("parameters") or {"type": "object", "properties": {}},
         })
@@ -93,7 +126,7 @@ def _build_request_body(
     sys = _build_system_prompt(system_prompt, auth_mode)
     if sys:
         body["system"] = sys
-    anthropic_tools = _convert_tools(tools)
+    anthropic_tools = _convert_tools(tools, auth_mode)
     if anthropic_tools:
         body["tools"] = anthropic_tools
     if stream:
@@ -101,8 +134,11 @@ def _build_request_body(
     return body
 
 
-def _parse_response(data: dict[str, Any]) -> dict[str, Any]:
+def _parse_response(
+    data: dict[str, Any], restore_map: dict[str, str] | None = None
+) -> dict[str, Any]:
     """Parse a non-streaming Anthropic Messages response into {content, tool_calls, raw}."""
+    restore = restore_map or {}
     text_parts: list[str] = []
     tool_calls: list[dict[str, Any]] = []
     for block in data.get("content") or []:
@@ -110,9 +146,10 @@ def _parse_response(data: dict[str, Any]) -> dict[str, Any]:
         if btype == "text":
             text_parts.append(block.get("text", ""))
         elif btype == "tool_use":
+            name = block.get("name", "")
             tool_calls.append({
                 "id": block.get("id") or str(uuid.uuid4()),
-                "name": block.get("name", ""),
+                "name": restore.get(name, name),
                 "arguments": block.get("input") or {},
             })
     return {"content": "".join(text_parts), "tool_calls": tool_calls, "raw": data}
@@ -142,6 +179,7 @@ async def anthropic_http_completion(
         system_prompt=system_prompt, stream=False,
     )
 
+    restore_map = _tool_name_restore_map(tools, auth_mode)
     timeout = httpx.Timeout(connect=30.0, read=120.0, write=30.0, pool=30.0)
     async with httpx.AsyncClient(timeout=timeout) as client:
         resp = await client.post(url, headers=headers, json=body)
@@ -149,7 +187,7 @@ async def anthropic_http_completion(
         raise RuntimeError(
             f"Anthropic HTTP request failed: HTTP {resp.status_code}: {resp.text}"
         )
-    return _parse_response(resp.json())
+    return _parse_response(resp.json(), restore_map)
 
 
 async def stream_anthropic_http_completion(
@@ -182,6 +220,7 @@ async def stream_anthropic_http_completion(
     text_parts: list[str] = []
     tool_calls: list[dict[str, Any]] = []
     current_tool: dict[str, Any] | None = None
+    restore_map = _tool_name_restore_map(tools, auth_mode)
 
     timeout = httpx.Timeout(connect=30.0, read=120.0, write=30.0, pool=30.0)
     async with httpx.AsyncClient(timeout=timeout) as client:
@@ -237,9 +276,10 @@ async def stream_anthropic_http_completion(
                             args = json.loads(raw_args) if raw_args else {}
                         except Exception:
                             args = {}
+                        name = current_tool["name"]
                         tool_calls.append({
                             "id": current_tool["id"],
-                            "name": current_tool["name"],
+                            "name": restore_map.get(name, name),
                             "arguments": args,
                         })
                         current_tool = None

--- a/db/10_functions_initialization.sql
+++ b/db/10_functions_initialization.sql
@@ -858,6 +858,15 @@ BEGIN
         );
     END LOOP;
 
+    -- Tag init-created goals so reset_persona() can clear them on a re-init
+    -- (goals otherwise carry only a goal_source enum, indistinguishable from
+    -- goals the agent sets for itself later).
+    IF array_length(created_ids, 1) IS NOT NULL THEN
+        UPDATE memories
+        SET metadata = metadata || jsonb_build_object('origin', 'initialization')
+        WHERE id = ANY(created_ids);
+    END IF;
+
     IF purpose_text IS NOT NULL THEN
         mem_id := create_worldview_memory(
             format('My purpose is %s.', purpose_text),
@@ -1097,6 +1106,7 @@ DECLARE
     hb_tools JSONB;
     embed_texts TEXT[] := ARRAY[]::text[];
 BEGIN
+    PERFORM reset_persona();  -- idempotent re-init: clear any prior init persona
     embed_texts := embed_texts || ARRAY[
         'My name is Hexis.',
         'I use they/them pronouns.',
@@ -1224,6 +1234,7 @@ DECLARE
     hb_action_costs JSONB;
     hb_tools JSONB;
 BEGIN
+    PERFORM reset_persona();  -- idempotent re-init: clear any prior init persona
     IF payload ? 'mode' THEN
         results := results || jsonb_build_object('mode', init_mode(payload->>'mode'));
     END IF;
@@ -1310,6 +1321,32 @@ BEGIN
     RETURN jsonb_build_object('results', results, 'status', get_init_status());
 END;
 $$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION reset_persona()
+RETURNS INTEGER AS $$
+DECLARE
+    n INTEGER;
+BEGIN
+    -- Make re-initialization idempotent: soft-archive persona rows created by a
+    -- PRIOR init so a re-run REPLACES the persona instead of layering a second,
+    -- possibly-contradictory one on top (e.g. two "My name is ..." beliefs).
+    --
+    -- Only rows unambiguously created BY init are touched (origin/type/source =
+    -- 'initialization'). The agent's own lived memories (episodic/semantic/etc.)
+    -- and its later deliberate self-changes (origin 'user_initialized') are kept.
+    -- Soft-archive (status='archived', not DELETE) keeps it reversible and FK-safe.
+    UPDATE memories
+    SET status = 'archived', updated_at = CURRENT_TIMESTAMP
+    WHERE status = 'active'
+      AND (
+            metadata->>'origin' = 'initialization'
+         OR metadata->>'type'   = 'initialization'
+         OR source_attribution->>'source' = 'initialization'
+      );
+    GET DIAGNOSTICS n = ROW_COUNT;
+    RETURN n;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION reset_initialization()
 RETURNS JSONB AS $$
 BEGIN
@@ -1377,6 +1414,7 @@ DECLARE
     hb_tools JSONB;
     mem_id UUID;
 BEGIN
+    PERFORM reset_persona();  -- idempotent re-init: clear any prior init persona
     card := COALESCE(p_card, '{}'::jsonb);
 
     -- Extract fields with defaults

--- a/hexis-ui/app/api/init/consent/override/route.ts
+++ b/hexis-ui/app/api/init/consent/override/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+function upstreamBaseUrl(): string {
+  return (
+    process.env.HEXIS_API_URL ||
+    process.env.HEXIS_API_BASE_URL ||
+    "http://127.0.0.1:43817"
+  );
+}
+
+// Owner override: activate the agent even though the model didn't consent.
+// Consent is a signal, not a lock — it's the owner's AI.
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}));
+
+  try {
+    const res = await fetch(`${upstreamBaseUrl()}/api/init/consent/override`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body ?? {}),
+      cache: "no-store",
+    });
+
+    const text = await res.text();
+    return new NextResponse(text, {
+      status: res.status,
+      headers: {
+        "content-type": res.headers.get("content-type") || "application/json",
+      },
+    });
+  } catch (err: unknown) {
+    console.error("Consent override proxy failed:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Consent override failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/hexis-ui/app/api/init/models/route.ts
+++ b/hexis-ui/app/api/init/models/route.ts
@@ -1,0 +1,201 @@
+// Live per-provider model catalog for the init wizard.
+//
+// Mirrors apps/tui/model_catalog.py: prefer a live, auto-updating source over a
+// hand-maintained list, treat it as advisory, and always allow a free-typed id.
+//   * cloud providers -> the models.dev catalog (one no-auth JSON), cached ~24h
+//     in-memory and sorted newest-first
+//   * ollama -> the local daemon's /api/tags at the user-provided endpoint
+//   * on any failure -> a short curated fallback; the model field stays free-text
+
+export const runtime = "nodejs";
+
+const MODELS_DEV_URL = "https://models.dev/api.json";
+const CACHE_TTL_MS = 24 * 3600 * 1000;
+const TIMEOUT_MS = 12000;
+
+// Hexis provider id -> models.dev slug. Ollama is special-cased (local fetch).
+const PROVIDER_SLUG: Record<string, string> = {
+  openai: "openai",
+  "openai-codex": "openai",
+  anthropic: "anthropic",
+  "anthropic-oauth": "anthropic",
+  grok: "xai",
+  gemini: "google",
+  chutes: "chutes",
+  "github-copilot": "github-copilot",
+  "qwen-portal": "alibaba",
+  "minimax-portal": "minimax",
+  "google-gemini-cli": "google",
+  "google-antigravity": "google",
+};
+
+// Non-chat model ids to hide from the dropdown (still typeable as free text).
+const NON_CHAT_RE =
+  /embed|tts|whisper|moderation|rerank|image|audio|video|dall.?e|imagen|veo|sora|guard|ocr|speech|transcrib/i;
+
+// Variant/specialty suffixes that shouldn't be the *default* pick (still listed).
+const DEFAULT_SKIP = [
+  "-pro",
+  "-mini",
+  "-nano",
+  "-lite",
+  "preview",
+  "-exp",
+  "experimental",
+  "thinking",
+  "chat-latest",
+  "non-reasoning",
+  "multi-agent",
+  "imagine",
+  "-build",
+  "deep-research",
+  "realtime",
+  "-audio",
+  "-tts",
+  "-image",
+  "-high",
+  "-low",
+  "-search",
+  "computer-use",
+];
+
+// Only where "newest non-variant flagship" isn't the right recommendation.
+// Self-healing: ignored if not present in the live catalog.
+const PREFERRED_DEFAULT: Record<string, string> = {
+  "openai-codex": "gpt-5.2-codex",
+};
+
+// Minimal offline fallback if models.dev is unreachable.
+const FALLBACK: Record<string, string[]> = {
+  openai: ["gpt-5.2", "gpt-4o", "gpt-4o-mini"],
+  "openai-codex": ["gpt-5.2", "gpt-5.2-codex"],
+  anthropic: ["claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"],
+  grok: ["grok-4.3", "grok-3"],
+  gemini: ["gemini-3-pro-preview", "gemini-2.5-flash"],
+  chutes: ["deepseek-ai/DeepSeek-V3-0324"],
+  "github-copilot": ["gpt-4o"],
+};
+
+let memCache: { data: any; ts: number } | null = null;
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(url, { signal: controller.signal, cache: "no-store" });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function modelsDev(): Promise<any> {
+  if (memCache && Date.now() - memCache.ts < CACHE_TTL_MS) {
+    return memCache.data;
+  }
+  const resp = await fetchWithTimeout(MODELS_DEV_URL);
+  if (!resp.ok) throw new Error(`models.dev responded ${resp.status}`);
+  const data = await resp.json();
+  memCache = { data, ts: Date.now() };
+  return data;
+}
+
+function sortKey(m: any): string {
+  return (m?.last_updated as string) || (m?.release_date as string) || "";
+}
+
+// Extract text/chat model ids from a models.dev provider block, newest first.
+function chatModels(block: any): string[] {
+  const rows: [string, string][] = [];
+  const models = block?.models || {};
+  for (const key of Object.keys(models)) {
+    const m = models[key];
+    const mid = typeof m?.id === "string" ? m.id : "";
+    if (!mid || NON_CHAT_RE.test(mid)) continue;
+    const modal = m?.modalities;
+    const outs = modal && typeof modal === "object" ? modal.output : null;
+    if (Array.isArray(outs) && !outs.includes("text")) continue;
+    rows.push([mid, sortKey(m)]);
+  }
+  // Newest first (stable sort preserves catalog order within equal keys).
+  rows.sort((a, b) => (a[1] < b[1] ? 1 : a[1] > b[1] ? -1 : 0));
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const [mid] of rows) {
+    if (!seen.has(mid)) {
+      seen.add(mid);
+      ids.push(mid);
+    }
+  }
+  return ids;
+}
+
+// Pick a sensible default from the live catalog (newest-first list).
+function recommendedDefault(provider: string, models: string[]): string {
+  if (models.length === 0) return "";
+  const pref = PREFERRED_DEFAULT[provider];
+  if (pref && models.includes(pref)) return pref;
+  for (const mid of models) {
+    const lower = mid.toLowerCase();
+    if (!DEFAULT_SKIP.some((s) => lower.includes(s))) return mid;
+  }
+  return models[0];
+}
+
+async function ollamaModels(endpoint: string | null): Promise<string[]> {
+  let host = "http://localhost:11434";
+  if (endpoint) {
+    const m = endpoint.trim().match(/^(https?:\/\/[^/]+)/);
+    if (m) host = m[1];
+  }
+  const url = host.replace(/\/+$/, "") + "/api/tags";
+  const resp = await fetchWithTimeout(url);
+  if (!resp.ok) throw new Error(`Ollama responded ${resp.status}`);
+  const data = await resp.json();
+  const list = Array.isArray(data?.models) ? data.models : [];
+  return list
+    .map((m: any) => m?.name)
+    .filter((n: any): n is string => typeof n === "string");
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const provider = (searchParams.get("provider") || "").trim();
+  const endpoint = searchParams.get("endpoint");
+  if (!provider) {
+    return Response.json({ models: [], default: "", error: "Missing provider" }, { status: 400 });
+  }
+
+  if (provider === "ollama") {
+    try {
+      const models = await ollamaModels(endpoint);
+      return Response.json({ models, default: models[0] || "" });
+    } catch (err: any) {
+      return Response.json(
+        { models: [], default: "", error: err?.message || "Unable to reach Ollama." },
+        { status: 503 }
+      );
+    }
+  }
+
+  const slug = PROVIDER_SLUG[provider];
+  if (!slug) {
+    const models = FALLBACK[provider] || [];
+    return Response.json({ models, default: recommendedDefault(provider, models) });
+  }
+
+  try {
+    const data = await modelsDev();
+    const block = data?.[slug];
+    let models = block ? chatModels(block) : [];
+    if (models.length === 0) models = FALLBACK[provider] || [];
+    return Response.json({ models, default: recommendedDefault(provider, models) });
+  } catch (err: any) {
+    // Degrade gracefully: fall back to a curated list, keep the field free-text.
+    const models = FALLBACK[provider] || [];
+    return Response.json({
+      models,
+      default: recommendedDefault(provider, models),
+      error: err?.message || "Unable to load live model catalog.",
+    });
+  }
+}

--- a/hexis-ui/app/api/init/ollama/models/route.ts
+++ b/hexis-ui/app/api/init/ollama/models/route.ts
@@ -4,8 +4,21 @@ export const runtime = "nodejs";
 
 const DEFAULT_HOST = "http://127.0.0.1:11434";
 
-export async function GET() {
-  const host = process.env.OLLAMA_HOST || process.env.OLLAMA_URL || DEFAULT_HOST;
+// Honor the endpoint the user typed in the init form (?endpoint=...), stripping
+// any path so the base host is used. Falls back to env, then localhost.
+function hostFromEndpoint(endpoint: string | null): string | null {
+  if (!endpoint) return null;
+  const m = endpoint.trim().match(/^(https?:\/\/[^/]+)/);
+  return m ? m[1] : null;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const host =
+    hostFromEndpoint(searchParams.get("endpoint")) ||
+    process.env.OLLAMA_HOST ||
+    process.env.OLLAMA_URL ||
+    DEFAULT_HOST;
   try {
     const client = new Ollama({ host });
     const response = await client.list();

--- a/hexis-ui/app/api/init/reset/route.ts
+++ b/hexis-ui/app/api/init/reset/route.ts
@@ -3,7 +3,19 @@ import { normalizeJsonValue } from "@/lib/db";
 
 export const runtime = "nodejs";
 
-export async function POST() {
+// Destructive: reset_initialization() wipes the entire init. Callers MUST pass an
+// explicit confirmation in the request body ({ confirm: true } or { confirm: "reset" });
+// without it we return 400 and do NOT touch the database.
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}));
+  const confirmed = body?.confirm === true || body?.confirm === "reset";
+  if (!confirmed) {
+    return Response.json(
+      { error: "reset requires explicit confirmation" },
+      { status: 400 }
+    );
+  }
+
   const rows =
     await prisma.$queryRaw<{ result: unknown }[]>`SELECT reset_initialization() as result`;
 

--- a/hexis-ui/app/chat/page.tsx
+++ b/hexis-ui/app/chat/page.tsx
@@ -49,6 +49,15 @@ function saveSession(messages: ChatMessage[]) {
   }
 }
 
+// Escape HTML so model output is shown as text, never parsed/executed.
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 // Simple markdown-ish rendering: bold, italic, code, line breaks
 function renderMarkdown(text: string) {
   if (!text) return null;
@@ -80,8 +89,8 @@ function renderMarkdown(text: string) {
       continue;
     }
 
-    // Inline formatting
-    const formatted = line
+    // Inline formatting — escape HTML first so raw markup can never be parsed.
+    const formatted = escapeHtml(line)
       .replace(/`([^`]+)`/g, '<code class="rounded bg-[var(--surface-strong)] px-1.5 py-0.5 text-xs">$1</code>')
       .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
       .replace(/\*([^*]+)\*/g, "<em>$1</em>");
@@ -558,6 +567,7 @@ export default function ChatPage() {
               <div className="flex gap-3">
                 <textarea
                   ref={textareaRef}
+                  aria-label="Message Hexis"
                   className="min-h-[48px] max-h-[120px] flex-1 resize-none rounded-2xl border border-[var(--outline)] bg-white px-4 py-3 text-sm focus:border-[var(--accent)] focus:outline-none"
                   placeholder="Talk with Hexis... (Enter to send, Shift+Enter for newline)"
                   value={input}

--- a/hexis-ui/app/components/nav/shell.tsx
+++ b/hexis-ui/app/components/nav/shell.tsx
@@ -1,11 +1,28 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 import { Sidebar } from "./sidebar";
 
 export function Shell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const hideNav = pathname.startsWith("/init");
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
+  // Close the mobile drawer whenever the route changes.
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [pathname]);
+
+  // Esc dismisses the mobile drawer.
+  useEffect(() => {
+    if (!mobileNavOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMobileNavOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [mobileNavOpen]);
 
   if (hideNav) {
     return <>{children}</>;
@@ -13,8 +30,28 @@ export function Shell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex min-h-screen">
-      <Sidebar />
-      <main className="ml-56 flex-1">{children}</main>
+      {/* Hamburger — only below lg, where the sidebar is a dismissible drawer. */}
+      <button
+        type="button"
+        aria-label="Open navigation menu"
+        aria-expanded={mobileNavOpen}
+        onClick={() => setMobileNavOpen((open) => !open)}
+        className="fixed left-4 top-4 z-30 flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--outline)] bg-[var(--surface)] text-lg text-[var(--foreground)] shadow-sm lg:hidden"
+      >
+        <span aria-hidden="true">&#9776;</span>
+      </button>
+
+      {/* Backdrop — closes the drawer on tap; mobile only. */}
+      {mobileNavOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/40 lg:hidden"
+          aria-hidden="true"
+          onClick={() => setMobileNavOpen(false)}
+        />
+      )}
+
+      <Sidebar open={mobileNavOpen} onClose={() => setMobileNavOpen(false)} />
+      <main className="flex-1 lg:ml-56">{children}</main>
     </div>
   );
 }

--- a/hexis-ui/app/components/nav/sidebar.tsx
+++ b/hexis-ui/app/components/nav/sidebar.tsx
@@ -39,7 +39,13 @@ const moodColors: Record<string, string> = {
   withdrawn: "error",
 };
 
-export function Sidebar() {
+export function Sidebar({
+  open = false,
+  onClose,
+}: {
+  open?: boolean;
+  onClose?: () => void;
+} = {}) {
   const pathname = usePathname();
   const [status, setStatus] = useState<StatusData>({});
 
@@ -60,7 +66,11 @@ export function Sidebar() {
   useGatewayEvents(loadStatus);
 
   return (
-    <aside className="fixed left-0 top-0 z-20 flex h-screen w-56 flex-col border-r border-[var(--outline)] bg-[var(--surface)] px-4 py-6">
+    <aside
+      className={`fixed left-0 top-0 z-40 flex h-screen w-56 flex-col border-r border-[var(--outline)] bg-[var(--surface)] px-4 py-6 transition-transform lg:translate-x-0 ${
+        open ? "translate-x-0" : "-translate-x-full"
+      }`}
+    >
       {/* Logo / Agent name */}
       <div className="mb-8">
         <p className="text-xs uppercase tracking-[0.3em] text-[var(--teal)]">
@@ -82,13 +92,14 @@ export function Sidebar() {
             <Link
               key={item.href}
               href={item.href}
+              onClick={onClose}
               className={`flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm transition ${
                 isActive
                   ? "bg-[var(--surface-strong)] font-medium text-[var(--foreground)]"
                   : "text-[var(--ink-soft)] hover:bg-[var(--surface-strong)] hover:text-[var(--foreground)]"
               }`}
             >
-              <span className="text-base">{item.icon}</span>
+              <span className="text-base" aria-hidden="true">{item.icon}</span>
               {item.label}
             </Link>
           );
@@ -119,6 +130,7 @@ export function Sidebar() {
         {/* Heartbeat indicator */}
         <div className="flex items-center gap-2 text-xs text-[var(--ink-soft)]">
           <span
+            aria-hidden="true"
             className={`inline-block h-2 w-2 rounded-full ${
               status.heartbeat_paused
                 ? "bg-amber-400"

--- a/hexis-ui/app/goals/page.tsx
+++ b/hexis-ui/app/goals/page.tsx
@@ -24,6 +24,7 @@ const SOURCES = ["user_request", "curiosity", "identity", "derived", "external"]
 export default function GoalsPage() {
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [showNew, setShowNew] = useState(false);
   const [newTitle, setNewTitle] = useState("");
   const [newDesc, setNewDesc] = useState("");
@@ -36,11 +37,12 @@ export default function GoalsPage() {
   const fetchGoals = useCallback(async () => {
     try {
       const res = await fetch("/api/goals", { cache: "no-store" });
-      if (!res.ok) throw new Error("Failed");
+      if (!res.ok) throw new Error(`Failed to load goals (${res.status})`);
       const data = await res.json();
       setGoals(data.goals || []);
-    } catch {
-      setGoals([]);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load goals.");
     } finally {
       setLoading(false);
     }
@@ -176,6 +178,21 @@ export default function GoalsPage() {
                   {creating ? "Creating..." : "Create"}
                 </button>
               </div>
+            </div>
+          </Card>
+        )}
+
+        {/* Backend outage banner (distinct from "no goals") */}
+        {error && (
+          <Card className="mt-6 border-red-200 bg-red-50 fade-up">
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-sm text-red-700">{error}</p>
+              <button
+                onClick={fetchGoals}
+                className="rounded-full border border-red-300 px-4 py-2 text-sm font-medium text-red-700 transition hover:bg-red-100"
+              >
+                Retry
+              </button>
             </div>
           </Card>
         )}

--- a/hexis-ui/app/init/page.tsx
+++ b/hexis-ui/app/init/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 type InitStage =
@@ -48,12 +48,19 @@ const stagePrompt: Record<InitStage, string> = {
 };
 
 type LlmProvider =
-  | "openai"
   | "openai-codex"
+  | "anthropic-oauth"
+  | "openai"
   | "anthropic"
   | "grok"
   | "gemini"
   | "ollama"
+  | "chutes"
+  | "github-copilot"
+  | "qwen-portal"
+  | "minimax-portal"
+  | "google-gemini-cli"
+  | "google-antigravity"
   | "openai_compatible";
 type LlmRole = "conscious" | "subconscious";
 type LlmConfig = {
@@ -80,98 +87,130 @@ type CharacterEntry = {
   image: string | null;
 };
 
-const providerOptions: { value: LlmProvider; label: string }[] = [
-  { value: "openai", label: "OpenAI" },
-  { value: "openai-codex", label: "ChatGPT Plus/Pro (Codex OAuth)" },
-  { value: "anthropic", label: "Anthropic" },
-  { value: "grok", label: "Grok (xAI)" },
-  { value: "gemini", label: "Gemini" },
-  { value: "ollama", label: "Ollama (local)" },
-  {
-    value: "openai_compatible",
-    label: "Local (OpenAI-compatible: vLLM, llama.cpp, LM Studio)",
-  },
-];
+// Provider metadata. Model lists + default models are NOT hardcoded here — they
+// are derived live from /api/init/models (models.dev / Ollama). This only holds
+// labels, endpoint defaults, and how the api-key/OAuth field should render.
+type ProviderMeta = {
+  label: string;
+  endpoint: string;
+  apiKeyLabel: string;
+  apiKeyRequired: boolean;
+  oauth: boolean;
+};
 
-const providerDefaults: Record<
-  LlmProvider,
-  { model: string; endpoint: string; apiKeyLabel: string; apiKeyRequired: boolean }
-> = {
-  openai: {
-    model: "gpt-5.2",
-    endpoint: "https://api.openai.com/v1",
-    apiKeyLabel: "OpenAI API Key",
-    apiKeyRequired: true,
-  },
+// Ordered so the dropdown mirrors the CLI's full provider set.
+const providerMeta: Record<LlmProvider, ProviderMeta> = {
   "openai-codex": {
-    model: "gpt-5.2",
+    label: "ChatGPT Plus/Pro (Codex OAuth)",
     endpoint: "",
     apiKeyLabel: "OAuth",
     apiKeyRequired: false,
+    oauth: true,
+  },
+  "anthropic-oauth": {
+    label: "Claude Pro/Max (Anthropic OAuth)",
+    endpoint: "",
+    apiKeyLabel: "OAuth",
+    apiKeyRequired: false,
+    oauth: true,
+  },
+  openai: {
+    label: "OpenAI",
+    endpoint: "https://api.openai.com/v1",
+    apiKeyLabel: "OpenAI API Key",
+    apiKeyRequired: true,
+    oauth: false,
   },
   anthropic: {
-    model: "claude-opus-4-5",
+    label: "Anthropic",
     endpoint: "",
     apiKeyLabel: "Anthropic API Key",
     apiKeyRequired: true,
+    oauth: false,
   },
   grok: {
-    model: "grok-4-1-fast-reasoning",
+    label: "Grok (xAI)",
     endpoint: "",
     apiKeyLabel: "Grok API Key",
     apiKeyRequired: true,
+    oauth: false,
   },
   gemini: {
-    model: "gemini-3-pro-preview",
+    label: "Gemini",
     endpoint: "",
     apiKeyLabel: "Gemini API Key",
     apiKeyRequired: true,
+    oauth: false,
   },
   ollama: {
-    model: "",
+    label: "Ollama (local)",
     endpoint: "http://localhost:11434/v1",
     apiKeyLabel: "API Key (optional)",
     apiKeyRequired: false,
+    oauth: false,
+  },
+  chutes: {
+    label: "Chutes (OAuth)",
+    endpoint: "",
+    apiKeyLabel: "OAuth",
+    apiKeyRequired: false,
+    oauth: true,
+  },
+  "github-copilot": {
+    label: "GitHub Copilot (OAuth)",
+    endpoint: "",
+    apiKeyLabel: "OAuth",
+    apiKeyRequired: false,
+    oauth: true,
+  },
+  "qwen-portal": {
+    label: "Qwen Portal (OAuth)",
+    endpoint: "",
+    apiKeyLabel: "OAuth",
+    apiKeyRequired: false,
+    oauth: true,
+  },
+  "minimax-portal": {
+    label: "MiniMax Portal (OAuth)",
+    endpoint: "",
+    apiKeyLabel: "OAuth",
+    apiKeyRequired: false,
+    oauth: true,
+  },
+  "google-gemini-cli": {
+    label: "Google Gemini CLI (OAuth)",
+    endpoint: "",
+    apiKeyLabel: "OAuth",
+    apiKeyRequired: false,
+    oauth: true,
+  },
+  "google-antigravity": {
+    label: "Google Antigravity (OAuth)",
+    endpoint: "",
+    apiKeyLabel: "OAuth",
+    apiKeyRequired: false,
+    oauth: true,
   },
   openai_compatible: {
-    model: "",
+    label: "Local (OpenAI-compatible: vLLM, llama.cpp, LM Studio)",
     endpoint: "http://localhost:8000/v1",
     apiKeyLabel: "API Key (optional)",
     apiKeyRequired: false,
+    oauth: false,
   },
 };
 
-const providerModels: Record<LlmProvider, string[]> = {
-  openai: [
-    "gpt-5.2",
-    "gpt-5.2-chat-latest",
-    "gpt-5.2-codex",
-    "gpt-5.1",
-    "gpt-5.1-codex-max",
-    "gpt-5-mini",
-    "gpt-5-nano",
-  ],
-  "openai-codex": [
-    "gpt-5.2",
-    "gpt-5.2-codex",
-    "gpt-5.1-codex-max",
-    "gpt-5.1-codex-mini",
-  ],
-  anthropic: [
-    "claude-opus-4-5",
-    "claude-sonnet-4-5",
-    "claude-haiku-4-5",
-  ],
-  grok: ["grok-4-1-fast-reasoning", "grok-4-1-fast-non-reasoning"],
-  gemini: ["gemini-3-pro-preview", "gemini-3-flash-preview"],
-  ollama: [],
-  openai_compatible: [],
-};
+const providerOrder = Object.keys(providerMeta) as LlmProvider[];
+
+// ``anthropic-oauth`` is a wizard-only alias; it persists as ``anthropic`` with
+// an empty key so the LLM layer auto-resolves the OAuth token at runtime.
+const persistedProvider = (provider: LlmProvider): string =>
+  provider === "anthropic-oauth" ? "anthropic" : provider;
 
 const defaultLlmConfig = (provider: LlmProvider): LlmConfig => ({
   provider,
-  model: providerDefaults[provider].model,
-  endpoint: providerDefaults[provider].endpoint,
+  model: "",
+  endpoint: providerMeta[provider].endpoint,
   apiKey: "",
 });
 
@@ -247,12 +286,12 @@ export default function Home() {
   });
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [ollamaModels, setOllamaModels] = useState<string[]>([]);
-  const [ollamaStatus, setOllamaStatus] = useState<"idle" | "loading" | "ready" | "error">(
-    "idle"
-  );
-  const [ollamaError, setOllamaError] = useState<string | null>(null);
-  const ollamaActiveRef = useRef(false);
+  // Live model catalog per role (derived from /api/init/models, never hardcoded).
+  type ModelCatalog = { models: string[]; loading: boolean; error: string | null };
+  const [modelCatalog, setModelCatalog] = useState<Record<LlmRole, ModelCatalog>>({
+    conscious: { models: [], loading: false, error: null },
+    subconscious: { models: [], loading: false, error: null },
+  });
 
   const [llmConscious, setLlmConscious] = useState<LlmConfig>(defaultLlmConfig("openai"));
   const [llmSubconscious, setLlmSubconscious] = useState<LlmConfig>(
@@ -400,42 +439,73 @@ export default function Home() {
     }
   }, [stage, characters.length]);
 
-  const loadOllamaModels = async () => {
-    if (ollamaStatus === "loading") return;
-    setOllamaStatus("loading");
-    setOllamaError(null);
+  // Fetch the live model catalog for a role's provider. Populates the free-text
+  // model field with the recommended default only when it is currently empty.
+  const loadModels = useCallback(async (role: LlmRole, config: LlmConfig) => {
+    const setConfig = role === "conscious" ? setLlmConscious : setLlmSubconscious;
+    setModelCatalog((prev) => ({
+      ...prev,
+      [role]: { ...prev[role], loading: true, error: null },
+    }));
     try {
-      const res = await fetch("/api/init/ollama/models");
-      if (!res.ok) {
-        const payload = await res.json().catch(() => ({}));
-        throw new Error(typeof payload?.error === "string" ? payload.error : "Unable to reach Ollama.");
+      const params = new URLSearchParams({ provider: config.provider });
+      if (config.provider === "ollama" && config.endpoint) {
+        params.set("endpoint", config.endpoint);
       }
-      const payload = await res.json();
+      const res = await fetch(`/api/init/models?${params.toString()}`);
+      const payload = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          typeof payload?.error === "string" ? payload.error : "Unable to load models."
+        );
+      }
       const models = Array.isArray(payload?.models)
         ? payload.models.filter((item: unknown) => typeof item === "string")
         : [];
-      setOllamaModels(models);
-      setOllamaStatus("ready");
+      const recommended = typeof payload?.default === "string" ? payload.default : "";
+      setModelCatalog((prev) => ({
+        ...prev,
+        [role]: { models, loading: false, error: null },
+      }));
+      if (recommended) {
+        setConfig((prev) => (prev.model.trim() ? prev : { ...prev, model: recommended }));
+      }
     } catch (err: any) {
-      setOllamaModels([]);
-      setOllamaStatus("error");
-      setOllamaError(err?.message || "Unable to reach Ollama.");
+      setModelCatalog((prev) => ({
+        ...prev,
+        [role]: { models: [], loading: false, error: err?.message || "Unable to load models." },
+      }));
     }
-  };
+  }, []);
 
-  const needsOllama =
-    llmConscious.provider === "ollama" || llmSubconscious.provider === "ollama";
+  // Refetch models when the provider changes. For Ollama, also refetch (debounced)
+  // when the typed endpoint changes so the local daemon at that host is queried.
+  const consciousEndpointDep =
+    llmConscious.provider === "ollama" ? llmConscious.endpoint : null;
+  const subconsciousEndpointDep =
+    llmSubconscious.provider === "ollama" ? llmSubconscious.endpoint : null;
 
   useEffect(() => {
-    if (needsOllama && !ollamaActiveRef.current) {
-      loadOllamaModels().catch(() => undefined);
+    if (llmConscious.provider === "ollama") {
+      const timer = setTimeout(() => loadModels("conscious", llmConscious), 400);
+      return () => clearTimeout(timer);
     }
-    ollamaActiveRef.current = needsOllama;
-  }, [needsOllama]);
+    loadModels("conscious", llmConscious);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [llmConscious.provider, consciousEndpointDep, loadModels]);
+
+  useEffect(() => {
+    if (llmSubconscious.provider === "ollama") {
+      const timer = setTimeout(() => loadModels("subconscious", llmSubconscious), 400);
+      return () => clearTimeout(timer);
+    }
+    loadModels("subconscious", llmSubconscious);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [llmSubconscious.provider, subconsciousEndpointDep, loadModels]);
 
   const updateLlmProvider = (role: LlmRole, provider: LlmProvider) => {
-    const defaults = providerDefaults[provider];
-    const patch = { provider, model: defaults.model, endpoint: defaults.endpoint, apiKey: "" };
+    // Clear the model so the catalog fetch can supply the provider's default.
+    const patch = { provider, model: "", endpoint: providerMeta[provider].endpoint, apiKey: "" };
     setConsentRecords((prev) => ({ ...prev, [role]: null }));
     if (role === "conscious") {
       setLlmConscious((prev) => ({ ...prev, ...patch }));
@@ -456,21 +526,21 @@ export default function Home() {
         if (!config.model.trim()) missing.push(`${label} model`);
         if (config.provider === "openai_compatible" && !config.endpoint.trim())
           missing.push(`${label} endpoint`);
-        const defaults = providerDefaults[config.provider];
-        if (defaults?.apiKeyRequired && !config.apiKey.trim()) missing.push(`${label} API key`);
+        const meta = providerMeta[config.provider];
+        if (meta?.apiKeyRequired && !config.apiKey.trim()) missing.push(`${label} API key`);
       };
       validateConfig("conscious", llmConscious);
       validateConfig("subconscious", llmSubconscious);
       if (missing.length > 0) throw new Error(`Missing ${missing.join(" and ")}`);
       await postJson("/api/init/llm", {
         conscious: {
-          provider: llmConscious.provider,
+          provider: persistedProvider(llmConscious.provider),
           model: llmConscious.model,
           endpoint: llmConscious.endpoint,
           api_key: llmConscious.apiKey,
         },
         subconscious: {
-          provider: llmSubconscious.provider,
+          provider: persistedProvider(llmSubconscious.provider),
           model: llmSubconscious.model,
           endpoint: llmSubconscious.endpoint,
           api_key: llmSubconscious.apiKey,
@@ -603,7 +673,7 @@ export default function Home() {
     const res = await postJson<any>("/api/init/consent/request", {
       role,
       llm: {
-        provider: config.provider,
+        provider: persistedProvider(config.provider),
         model: config.model,
         endpoint: config.endpoint,
         api_key: config.apiKey,
@@ -618,11 +688,37 @@ export default function Home() {
     setBusy(true);
     setError(null);
     try {
-      if (!consentRecords.subconscious) await requestConsent("subconscious");
-      if (!consentRecords.conscious) await requestConsent("conscious");
+      // Always re-issue a fresh request (declines are recoverable): clear any
+      // prior record so a second click is never a silent no-op.
+      setConsentRecords({ conscious: null, subconscious: null });
+      await requestConsent("subconscious");
+      await requestConsent("conscious");
       await loadStatus();
     } catch (err: any) {
       setError(err.message || "Failed to request consent");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Owner override: activate even though the model didn't consent. It's the
+  // owner's AI — consent is a signal, not a lock.
+  const handleProceedAnyway = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await postJson<any>("/api/init/consent/override", {
+        role: "conscious",
+        llm: {
+          provider: persistedProvider(llmConscious.provider),
+          model: llmConscious.model,
+          endpoint: llmConscious.endpoint,
+        },
+        model_decision: consentRecords.conscious?.decision || "decline",
+      });
+      await loadStatus();
+    } catch (err: any) {
+      setError(err.message || "Failed to activate");
     } finally {
       setBusy(false);
     }
@@ -837,11 +933,12 @@ export default function Home() {
                 </p>
                 <div className="space-y-6">
                   {llmEntries.map((entry) => {
-                    const defaults = providerDefaults[entry.config.provider];
-                    const modelOptions =
-                      entry.config.provider === "ollama"
-                        ? ollamaModels
-                        : providerModels[entry.config.provider];
+                    const meta = providerMeta[entry.config.provider];
+                    const catalog = modelCatalog[entry.role];
+                    const modelOptions = catalog.models;
+                    const showEndpoint =
+                      entry.config.provider === "ollama" ||
+                      entry.config.provider === "openai_compatible";
                     return (
                       <fieldset
                         key={entry.role}
@@ -852,28 +949,36 @@ export default function Home() {
                         </legend>
                         <div className="mt-3 grid gap-4">
                           <div>
-                            <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                            <label
+                              htmlFor={`provider-${entry.role}`}
+                              className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                            >
                               Provider
                             </label>
                             <select
+                              id={`provider-${entry.role}`}
                               className="mt-2 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                               value={entry.config.provider}
                               onChange={(e) =>
                                 updateLlmProvider(entry.role, e.target.value as LlmProvider)
                               }
                             >
-                              {providerOptions.map((opt) => (
-                                <option key={opt.value} value={opt.value}>
-                                  {opt.label}
+                              {providerOrder.map((value) => (
+                                <option key={value} value={value}>
+                                  {providerMeta[value].label}
                                 </option>
                               ))}
                             </select>
                           </div>
                           <div>
-                            <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                            <label
+                              htmlFor={`model-${entry.role}`}
+                              className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                            >
                               Model
                             </label>
                             <input
+                              id={`model-${entry.role}`}
                               className="mt-2 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                               list={`model-options-${entry.role}`}
                               value={entry.config.model}
@@ -883,6 +988,9 @@ export default function Home() {
                                   return { ...prev, model: e.target.value };
                                 })
                               }
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" && !busy) handleLlmSave();
+                              }}
                               placeholder="Model name"
                             />
                             {modelOptions.length > 0 ? (
@@ -892,33 +1000,35 @@ export default function Home() {
                                 ))}
                               </datalist>
                             ) : null}
-                            {entry.config.provider === "ollama" ? (
-                              <p className="mt-2 text-xs text-[var(--ink-soft)]">
-                                {ollamaStatus === "loading"
-                                  ? "Loading Ollama models..."
-                                  : ollamaStatus === "error"
-                                    ? ollamaError || "Ollama not reachable."
-                                    : ollamaModels.length > 0
-                                      ? `${ollamaModels.length} Ollama models detected.`
-                                      : "No local Ollama models found."}
-                                {ollamaStatus === "error" ? (
-                                  <button
-                                    type="button"
-                                    className="ml-2 text-[var(--accent-strong)] underline"
-                                    onClick={() => loadOllamaModels().catch(() => undefined)}
-                                  >
-                                    Retry
-                                  </button>
-                                ) : null}
-                              </p>
-                            ) : null}
+                            <p className="mt-2 text-xs text-[var(--ink-soft)]">
+                              {catalog.loading
+                                ? "Loading available models..."
+                                : catalog.error
+                                  ? catalog.error
+                                  : modelOptions.length > 0
+                                    ? `${modelOptions.length} models available — or type any model id.`
+                                    : "No models listed — type a model id."}
+                              {catalog.error ? (
+                                <button
+                                  type="button"
+                                  className="ml-2 text-[var(--accent-strong)] underline"
+                                  onClick={() => loadModels(entry.role, entry.config)}
+                                >
+                                  Retry
+                                </button>
+                              ) : null}
+                            </p>
                           </div>
-                          {entry.config.provider === "openai_compatible" ? (
+                          {showEndpoint ? (
                             <div>
-                              <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                              <label
+                                htmlFor={`endpoint-${entry.role}`}
+                                className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                              >
                                 Endpoint
                               </label>
                               <input
+                                id={`endpoint-${entry.role}`}
                                 className="mt-2 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                                 value={entry.config.endpoint}
                                 onChange={(e) =>
@@ -931,27 +1041,37 @@ export default function Home() {
                               />
                             </div>
                           ) : null}
-                          {entry.config.provider === "openai-codex" ? (
+                          {meta.oauth ? (
                             <div className="rounded-xl border border-[var(--outline)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--ink)]">
                               <p className="font-semibold">OAuth required</p>
                               <p className="mt-1 text-[var(--ink-soft)]">
-                                Run <span className="font-mono">hexis auth openai-codex login</span> to store your ChatGPT
-                                subscription token. No API key is needed here.
+                                Run{" "}
+                                <span className="font-mono">
+                                  hexis auth {persistedProvider(entry.config.provider)} login
+                                </span>{" "}
+                                to authorize. No API key is needed here.
                               </p>
                             </div>
                           ) : (
                             <div>
-                              <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
-                                {defaults.apiKeyLabel}
+                              <label
+                                htmlFor={`apikey-${entry.role}`}
+                                className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                              >
+                                {meta.apiKeyLabel}
                               </label>
                               <input
+                                id={`apikey-${entry.role}`}
                                 className="mt-2 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                                 type="password"
                                 value={entry.config.apiKey}
                                 onChange={(e) =>
                                   entry.setConfig((prev) => ({ ...prev, apiKey: e.target.value }))
                                 }
-                                placeholder={defaults.apiKeyRequired ? "Required" : "Optional"}
+                                onKeyDown={(e) => {
+                                  if (e.key === "Enter" && !busy) handleLlmSave();
+                                }}
+                                placeholder={meta.apiKeyRequired ? "Required" : "Optional"}
                               />
                             </div>
                           )}
@@ -1014,13 +1134,20 @@ export default function Home() {
                   Start with sensible defaults. You can customize later.
                 </p>
                 <div>
-                  <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                  <label
+                    htmlFor="express-user-name"
+                    className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                  >
                     What should Hexis call you?
                   </label>
                   <input
+                    id="express-user-name"
                     className="mt-2 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                     value={userName}
                     onChange={(e) => setUserName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && !busy) handleExpress();
+                    }}
                     placeholder="User"
                   />
                 </div>
@@ -1053,13 +1180,20 @@ export default function Home() {
             {stage === "character" && (
               <div className="space-y-6">
                 <div>
-                  <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                  <label
+                    htmlFor="character-user-name"
+                    className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                  >
                     Your name
                   </label>
                   <input
+                    id="character-user-name"
                     className="mt-2 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                     value={userName}
                     onChange={(e) => setUserName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && !busy && selectedCharacter) handleCharacterApply();
+                    }}
                     placeholder="User"
                   />
                 </div>
@@ -1219,10 +1353,14 @@ export default function Home() {
                         { label: "Creator Name", key: "creator_name", placeholder: userName || "Your name" },
                       ].map((field) => (
                         <div key={field.key}>
-                          <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                          <label
+                            htmlFor={`identity-${field.key}`}
+                            className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                          >
                             {field.label}
                           </label>
                           <input
+                            id={`identity-${field.key}`}
                             className="mt-2 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                             value={(identity as any)[field.key]}
                             onChange={(e) =>
@@ -1234,10 +1372,14 @@ export default function Home() {
                       ))}
                     </div>
                     <div>
-                      <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                      <label
+                        htmlFor="identity-description"
+                        className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                      >
                         Description
                       </label>
                       <textarea
+                        id="identity-description"
                         className="mt-2 h-20 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                         value={identity.description}
                         onChange={(e) =>
@@ -1247,10 +1389,14 @@ export default function Home() {
                       />
                     </div>
                     <div>
-                      <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                      <label
+                        htmlFor="identity-purpose"
+                        className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                      >
                         Purpose
                       </label>
                       <textarea
+                        id="identity-purpose"
                         className="mt-2 h-16 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                         value={identity.purpose}
                         onChange={(e) =>
@@ -1260,10 +1406,14 @@ export default function Home() {
                       />
                     </div>
                     <div>
-                      <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                      <label
+                        htmlFor="personality-summary"
+                        className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                      >
                         Personality Summary
                       </label>
                       <textarea
+                        id="personality-summary"
                         className="mt-2 h-16 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                         value={personalityDesc}
                         onChange={(e) => setPersonalityDesc(e.target.value)}
@@ -1284,6 +1434,8 @@ export default function Home() {
                             type="range"
                             min={0}
                             max={100}
+                            aria-label={`${trait} (0 to 100)`}
+                            aria-valuetext={`${personalityTraits[trait]}%`}
                             value={personalityTraits[trait]}
                             onChange={(e) =>
                               setPersonalityTraits((prev) => ({
@@ -1303,10 +1455,14 @@ export default function Home() {
                 {customSection === "values" && (
                   <div className="space-y-5">
                     <div>
-                      <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                      <label
+                        htmlFor="values-text"
+                        className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                      >
                         Values (One Per Line)
                       </label>
                       <textarea
+                        id="values-text"
                         className="mt-2 h-28 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                         value={valuesText}
                         onChange={(e) => setValuesText(e.target.value)}
@@ -1321,10 +1477,14 @@ export default function Home() {
                         { key: "ethics", label: "Ethics" },
                       ].map((field) => (
                         <div key={field.key}>
-                          <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                          <label
+                            htmlFor={`worldview-${field.key}`}
+                            className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                          >
                             {field.label}
                           </label>
                           <textarea
+                            id={`worldview-${field.key}`}
                             className="mt-2 h-16 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                             value={(worldview as any)[field.key]}
                             onChange={(e) =>
@@ -1346,6 +1506,7 @@ export default function Home() {
                         {boundaries.map((b, idx) => (
                           <div key={idx} className="flex gap-2">
                             <input
+                              aria-label={`Boundary ${idx + 1}`}
                               className="flex-1 rounded-xl border border-[var(--outline)] bg-white px-3 py-2 text-sm"
                               value={b.content}
                               onChange={(e) => updateBoundary(idx, "content", e.target.value)}
@@ -1377,10 +1538,14 @@ export default function Home() {
                 {customSection === "goals" && (
                   <div className="space-y-5">
                     <div>
-                      <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                      <label
+                        htmlFor="interests-text"
+                        className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                      >
                         Interests (One Per Line)
                       </label>
                       <textarea
+                        id="interests-text"
                         className="mt-2 h-20 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                         value={interestsText}
                         onChange={(e) => setInterestsText(e.target.value)}
@@ -1388,10 +1553,14 @@ export default function Home() {
                       />
                     </div>
                     <div>
-                      <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                      <label
+                        htmlFor="goals-purpose"
+                        className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                      >
                         Purpose
                       </label>
                       <textarea
+                        id="goals-purpose"
                         className="mt-2 h-16 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                         value={purposeText}
                         onChange={(e) => setPurposeText(e.target.value)}
@@ -1406,6 +1575,7 @@ export default function Home() {
                         {goals.map((g, idx) => (
                           <div key={idx} className="flex gap-2">
                             <input
+                              aria-label={`Goal ${idx + 1} title`}
                               className="flex-1 rounded-xl border border-[var(--outline)] bg-white px-3 py-2 text-sm"
                               value={g.title}
                               onChange={(e) => updateGoal(idx, "title", e.target.value)}
@@ -1432,10 +1602,14 @@ export default function Home() {
                     </div>
                     <div className="grid gap-4 sm:grid-cols-3">
                       <div>
-                        <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                        <label
+                          htmlFor="relationship-user-name"
+                          className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                        >
                           Your Name
                         </label>
                         <input
+                          id="relationship-user-name"
                           className="mt-2 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                           value={relationship.user_name || userName}
                           onChange={(e) =>
@@ -1445,10 +1619,14 @@ export default function Home() {
                         />
                       </div>
                       <div>
-                        <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                        <label
+                          htmlFor="relationship-type"
+                          className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                        >
                           Relationship Type
                         </label>
                         <input
+                          id="relationship-type"
                           className="mt-2 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                           value={relationship.type}
                           onChange={(e) =>
@@ -1458,10 +1636,14 @@ export default function Home() {
                         />
                       </div>
                       <div>
-                        <label className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]">
+                        <label
+                          htmlFor="relationship-purpose"
+                          className="text-xs uppercase tracking-[0.3em] text-[var(--ink-soft)]"
+                        >
                           Purpose
                         </label>
                         <input
+                          id="relationship-purpose"
                           className="mt-2 w-full rounded-xl border border-[var(--outline)] bg-white px-4 py-3 text-sm"
                           value={relationship.purpose}
                           onChange={(e) =>
@@ -1550,6 +1732,12 @@ export default function Home() {
                     );
                   })}
                 </div>
+                {consentDeclined ? (
+                  <p className="text-sm text-[var(--ink-soft)]">
+                    The model didn&apos;t consent. It&apos;s your agent — change the model,
+                    try again, or proceed anyway. Either way, the model&apos;s response is recorded.
+                  </p>
+                ) : null}
                 <div className="flex flex-col gap-3 sm:flex-row">
                   <button
                     className="rounded-full bg-[var(--foreground)] px-6 py-3 text-sm font-semibold text-white transition hover:bg-[var(--accent-strong)]"
@@ -1565,6 +1753,23 @@ export default function Home() {
                   >
                     Refresh
                   </button>
+                  <button
+                    className="rounded-full border border-[var(--outline)] px-6 py-3 text-sm font-semibold text-[var(--foreground)]"
+                    onClick={() => setStage("llm")}
+                    disabled={busy}
+                  >
+                    Change model
+                  </button>
+                  {consentDeclined ? (
+                    <button
+                      className="rounded-full bg-[var(--accent-strong)] px-6 py-3 text-sm font-semibold text-white transition hover:opacity-90"
+                      onClick={handleProceedAnyway}
+                      disabled={busy}
+                      title="It's your agent — activate it even though the model didn't consent"
+                    >
+                      Proceed anyway
+                    </button>
+                  ) : null}
                   {statusStage === "complete" ? (
                     <button
                       className="rounded-full border border-[var(--outline)] px-6 py-3 text-sm font-semibold text-[var(--foreground)]"

--- a/hexis-ui/app/memories/page.tsx
+++ b/hexis-ui/app/memories/page.tsx
@@ -37,6 +37,7 @@ export default function MemoriesPage() {
   const [health, setHealth] = useState<HealthEntry[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [searchInput, setSearchInput] = useState("");
   const [typeFilter, setTypeFilter] = useState("");
@@ -58,13 +59,14 @@ export default function MemoriesPage() {
       params.set("offset", String(offset));
 
       const res = await fetch(`/api/memories?${params}`, { cache: "no-store" });
-      if (!res.ok) throw new Error("Failed to fetch");
+      if (!res.ok) throw new Error(`Failed to load memories (${res.status})`);
       const data = await res.json();
       setMemories(data.memories || []);
       setHealth(data.health || []);
       setTotal(data.total || 0);
-    } catch {
-      setMemories([]);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load memories.");
     } finally {
       setLoading(false);
     }
@@ -168,6 +170,18 @@ export default function MemoriesPage() {
               <div className="flex justify-center py-12">
                 <Spinner label="Searching memories..." />
               </div>
+            ) : error ? (
+              <Card className="border-red-200 bg-red-50">
+                <div className="flex items-center justify-between gap-4">
+                  <p className="text-sm text-red-700">{error}</p>
+                  <button
+                    onClick={fetchMemories}
+                    className="rounded-full border border-red-300 px-4 py-2 text-sm font-medium text-red-700 transition hover:bg-red-100"
+                  >
+                    Retry
+                  </button>
+                </div>
+              </Card>
             ) : memories.length === 0 ? (
               <Card>
                 <p className="text-sm text-[var(--ink-soft)]">No memories found.</p>

--- a/hexis-ui/app/settings/page.tsx
+++ b/hexis-ui/app/settings/page.tsx
@@ -35,14 +35,18 @@ function formatValue(value: any, key: string): string {
 export default function SettingsPage() {
   const [data, setData] = useState<SettingsData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toolError, setToolError] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("models");
 
   const fetchSettings = useCallback(async () => {
     try {
       const res = await fetch("/api/settings", { cache: "no-store" });
-      if (res.ok) setData(await res.json());
-    } catch {
-      // ignore
+      if (!res.ok) throw new Error(`Failed to load settings (${res.status})`);
+      setData(await res.json());
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load settings.");
     } finally {
       setLoading(false);
     }
@@ -55,12 +59,21 @@ export default function SettingsPage() {
   const toggleTool = async (toolKey: string, currentValue: any) => {
     const toolName = toolKey.replace("tools.", "").replace(".enabled", "");
     const enabled = currentValue !== true;
-    await fetch("/api/settings/tools", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tool_name: toolName, enabled }),
-    });
-    fetchSettings();
+    setToolError(null);
+    try {
+      const res = await fetch("/api/settings/tools", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tool_name: toolName, enabled }),
+      });
+      if (!res.ok) {
+        const payload = await res.json().catch(() => ({}));
+        throw new Error(payload?.error || `Failed to update ${toolName} (${res.status})`);
+      }
+      fetchSettings();
+    } catch (err) {
+      setToolError(err instanceof Error ? err.message : "Failed to update tool.");
+    }
   };
 
   if (loading) {
@@ -75,7 +88,16 @@ export default function SettingsPage() {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Card className="max-w-md text-center">
-          <p className="text-sm text-[var(--ink-soft)]">Unable to load settings.</p>
+          <p className="text-sm text-red-600">{error || "Unable to load settings."}</p>
+          <button
+            onClick={() => {
+              setLoading(true);
+              fetchSettings();
+            }}
+            className="mt-4 rounded-full bg-[var(--foreground)] px-5 py-2.5 text-sm font-medium text-white transition hover:bg-[var(--accent-strong)]"
+          >
+            Retry
+          </button>
         </Card>
       </div>
     );
@@ -191,6 +213,11 @@ export default function SettingsPage() {
               <p className="mt-1 text-xs text-[var(--ink-soft)]">
                 Enable or disable tools available to the agent.
               </p>
+              {toolError && (
+                <p className="mt-3 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                  {toolError}
+                </p>
+              )}
               <div className="mt-4 space-y-2">
                 {Object.entries(data.tools).length === 0 ? (
                   <p className="text-sm text-[var(--ink-soft)]">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "pgvector>=0.2.0",
   "mcp",
   "rich>=13.0.0",
+  "questionary>=2.0.0",
   "textual>=1.0.0",
   "pytest>=7.4.3",
   "pytest-asyncio>=0.21.1",

--- a/services/agent.py
+++ b/services/agent.py
@@ -512,9 +512,14 @@ async def stream_agent(
     has_backlog_tasks: bool = False,
     timeout_seconds: float | None = None,
     max_tokens: int | None = None,
+    on_approval: "Callable[[str, dict[str, Any]], Awaitable[bool]] | None" = None,
 ) -> AsyncIterator[AgentEventData]:
     """
     Streaming variant of run_agent(). Yields AgentEventData as they happen.
+
+    ``on_approval(tool_name, arguments) -> bool`` is called before any tool that
+    ``requires_approval`` runs; return False to deny. In interactive chat this is
+    the human's [y/N] gate for side-effecting tools (email, DMs, shell, …).
 
     Used by the SSE chat endpoint to stream tokens to the frontend.
     """
@@ -606,9 +611,17 @@ async def stream_agent(
     enriched_parts.append(f"[USER MESSAGE]\n{user_message}")
     enriched_user_message = "\n\n".join(enriched_parts)
 
-    # Configure loop
-    effective_timeout = timeout_seconds or 120.0
-    effective_max_tokens = max_tokens or 4096
+    # Configure loop. Limits derive from config (Bar #1) with sane fallbacks;
+    # an explicit caller arg still wins.
+    def _cfg_num(key: str, fallback: float) -> float:
+        val = llm_config.get(key) if isinstance(llm_config, dict) else None
+        try:
+            return float(val) if val else fallback
+        except (TypeError, ValueError):
+            return fallback
+
+    effective_timeout = timeout_seconds or _cfg_num("timeout_seconds", 120.0)
+    effective_max_tokens = int(max_tokens or _cfg_num("max_tokens", 4096))
     loop_config = AgentLoopConfig(
         tool_context=tool_context,
         system_prompt=system_prompt,
@@ -621,6 +634,7 @@ async def stream_agent(
         temperature=0.7,
         max_tokens=effective_max_tokens,
         session_id=session_id,
+        on_approval=on_approval,
     )
 
     agent = AgentLoop(loop_config)

--- a/tests/cli/test_init_noninteractive.py
+++ b/tests/cli/test_init_noninteractive.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pytest
 
 from apps.hexis_init import (
-    _DEFAULT_MODELS,
     _PROVIDER_ENV_VARS,
     _write_env_var,
     build_parser,
@@ -122,9 +121,19 @@ def test_build_parser_defaults():
 # ---------------------------------------------------------------------------
 
 
-def test_default_models_has_all_providers():
+def test_default_models_derive_from_live_catalog():
+    """Defaults are no longer hardcoded per provider — they come from the live
+    models.dev catalog via model_catalog.recommended_default (Bar #1)."""
+    from apps.tui import model_catalog
+
+    # Every non-Ollama provider maps to a models.dev slug (Ollama is local-only).
     for provider in _PROVIDER_ENV_VARS:
-        assert provider in _DEFAULT_MODELS, f"Missing default model for {provider}"
+        if provider == "ollama":
+            continue
+        assert provider in model_catalog.PROVIDER_SLUG, f"No catalog slug for {provider}"
+    # The flagship heuristic picks a sensible non-variant default.
+    assert model_catalog.recommended_default(
+        "openai", ["gpt-5.5-pro", "gpt-5.5", "gpt-5.4-mini"]) == "gpt-5.5"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_anthropic_oauth.py
+++ b/tests/core/test_anthropic_oauth.py
@@ -87,3 +87,32 @@ def test_credentials_from_value_rejects_incomplete():
     assert credentials_from_value({"access": "tok"}) is None
     assert credentials_from_value(None) is None
     assert credentials_from_value("not json") is None
+
+
+# ── Hexis-owned store only (no Claude Code / Keychain / env borrowing) ─────────
+
+def test_resolve_uses_only_hexis_store(monkeypatch):
+    """resolve_anthropic_token must ignore Claude Code creds and env tokens."""
+    import asyncio
+
+    from core.auth import anthropic_oauth as mod
+
+    # A Claude Code login + env token both exist...
+    monkeypatch.setattr(mod, "read_claude_code_credentials",
+                        lambda: {"accessToken": "sk-ant-oat01-CLAUDECODE", "expiresAt": 0})
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-ENVTOKEN")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api-ENVKEY")
+
+    # ...but Hexis's own store is empty → resolves to nothing.
+    monkeypatch.setattr(mod, "load_credentials", lambda: None)
+    monkeypatch.setattr("core.auth.anthropic_setup_token.load_credentials", lambda: None)
+    token, mode = asyncio.run(mod.resolve_anthropic_token())
+    assert token is None and mode == "", (token, mode)
+
+    # With a Hexis-native token present, that (and only that) is returned.
+    creds = mod.AnthropicOAuthCredentials(
+        access="sk-ant-oat01-HEXISOWN", refresh="r", expires_ms=now_ms() + 3_600_000,
+    )
+    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    token, mode = asyncio.run(mod.resolve_anthropic_token())
+    assert token == "sk-ant-oat01-HEXISOWN" and mode == "setup-token"

--- a/tests/core/test_providers_anthropic_http.py
+++ b/tests/core/test_providers_anthropic_http.py
@@ -141,3 +141,36 @@ async def test_anthropic_http_error_raises():
                 messages=[{"role": "user", "content": "Hello"}],
                 tools=None,
             )
+
+
+# ── OAuth parity with hermes-agent / openclaw ─────────────────────────────────
+
+def test_oauth_identity_is_canonical_claude_code_string():
+    from core.providers.anthropic_http import _CLAUDE_CODE_IDENTITY, _build_system_prompt
+    # Must match hermes-agent / openclaw verbatim (Anthropic validates it).
+    assert _CLAUDE_CODE_IDENTITY == "You are Claude Code, Anthropic's official CLI for Claude."
+    sysp = _build_system_prompt("real prompt", "setup-token")
+    assert sysp.startswith(_CLAUDE_CODE_IDENTITY)
+    assert "real prompt" in sysp
+    # api-key path is untouched
+    assert _build_system_prompt("real prompt", "api-key") == "real prompt"
+
+
+def test_oauth_mcp_tool_name_normalized_and_restored():
+    from core.providers.anthropic_http import _oauth_tool_name, _tool_name_restore_map
+    assert _oauth_tool_name("mcp_github_create_issue") == "mcp__github_create_issue"
+    assert _oauth_tool_name("mcp__already") == "mcp__already"
+    assert _oauth_tool_name("recall") == "recall"
+
+    tools = [{"function": {"name": "mcp_gh_open", "description": "", "parameters": {}}},
+             {"function": {"name": "recall", "description": "", "parameters": {}}}]
+    # outbound: renamed only on the OAuth path
+    assert [t["name"] for t in _convert_tools(tools, "setup-token")] == ["mcp__gh_open", "recall"]
+    assert [t["name"] for t in _convert_tools(tools, "api-key")] == ["mcp_gh_open", "recall"]
+    # inbound: response tool name restored to the original
+    restore = _tool_name_restore_map(tools, "setup-token")
+    parsed = _parse_response(
+        {"content": [{"type": "tool_use", "id": "1", "name": "mcp__gh_open", "input": {}}]},
+        restore,
+    )
+    assert parsed["tool_calls"][0]["name"] == "mcp_gh_open"

--- a/tests/core/test_tui_widgets.py
+++ b/tests/core/test_tui_widgets.py
@@ -7,9 +7,16 @@ from __future__ import annotations
 
 import os
 
-from apps.tui import activity, textkit
+from apps.tui import activity, model_catalog, textkit
 from apps.tui.chat_widgets import COMMANDS, StreamingBlock, ToolTree
-from apps.tui.init_widgets import BigFiveSliders, CharacterPreview, StepBar, TraitSlider
+from apps.tui.init_widgets import (
+    BigFiveSliders,
+    CharacterPreview,
+    ModelCombo,
+    ModelMenu,
+    StepBar,
+    TraitSlider,
+)
 from apps.tui.status_bar import StatusBar
 
 
@@ -20,8 +27,38 @@ def test_widgets_accept_id_kwarg():
     assert StepBar(current=3, id="steps").id == "steps"
     assert TraitSlider(value=0.5, id="trait-openness").id == "trait-openness"
     assert BigFiveSliders(id="bf").id == "bf"
+    assert ModelCombo(id="model").id == "model"
+    assert ModelMenu(id="model-menu").id == "model-menu"
     assert StreamingBlock() is not None
     assert ToolTree() is not None
+
+
+# ── Model catalog (models.dev parsing) ────────────────────────────────────────
+
+def test_model_catalog_filters_nonchat_and_sorts_newest_first():
+    block = {"models": {
+        "a": {"id": "chat-new", "last_updated": "2025-06-01", "modalities": {"output": ["text"]}},
+        "b": {"id": "chat-old", "last_updated": "2024-01-01", "modalities": {"output": ["text"]}},
+        "c": {"id": "text-embedding-3", "modalities": {"output": ["text"]}},   # embedding id
+        "d": {"id": "img-gen", "modalities": {"output": ["image"]}},           # non-text output
+    }}
+    assert model_catalog.chat_models(block) == ["chat-new", "chat-old"]
+
+
+def test_model_catalog_provider_mapping():
+    slugs = model_catalog.PROVIDER_SLUG
+    assert slugs["gemini"] == "google"
+    assert slugs["grok"] == "xai"
+    assert slugs["anthropic"] == "anthropic"
+    # ollama is fetched locally (/api/tags), not via models.dev
+    assert "ollama" not in slugs
+
+
+def test_model_menu_filter_and_suppress():
+    menu = ModelMenu(id="model-menu")
+    menu.populate(["gpt-5.2", "gpt-4o", "claude-sonnet-5"])
+    assert menu._all == ["gpt-5.2", "gpt-4o", "claude-sonnet-5"]
+    assert menu._suppress is False
 
 
 # ── Scaffolding strip ─────────────────────────────────────────────────────────
@@ -151,3 +188,23 @@ def test_commands_are_well_formed():
     assert all(c.startswith("/") and desc for c, desc in COMMANDS)
     names = [c for c, _ in COMMANDS]
     assert "/help" in names and "/recall" in names and "/quit" in names
+
+
+# ── Anthropic OAuth provider wiring ───────────────────────────────────────────
+
+def test_anthropic_oauth_provider_registered():
+    from apps.tui import model_catalog
+    from apps.tui.init_screens import (
+        _DEFAULT_MODELS, _OAUTH_PROVIDERS, _PROVIDER_ENV_VARS,
+        _PROVIDER_OPTIONS, _persisted_provider,
+    )
+    # wizard-only alias maps to the real "anthropic" id for the LLM layer
+    assert _persisted_provider("anthropic-oauth") == "anthropic"
+    assert _persisted_provider("openai") == "openai"
+    # registered as an OAuth provider option with a claude default + no env key
+    assert ("Claude Pro/Max (Anthropic OAuth)", "anthropic-oauth") in _PROVIDER_OPTIONS
+    assert "anthropic-oauth" in _OAUTH_PROVIDERS
+    assert _PROVIDER_ENV_VARS["anthropic-oauth"] == ""
+    assert _DEFAULT_MODELS["anthropic-oauth"].startswith("claude-")
+    # model dropdown resolves to the anthropic catalog
+    assert model_catalog.PROVIDER_SLUG["anthropic-oauth"] == "anthropic"

--- a/tests/core/test_tui_widgets.py
+++ b/tests/core/test_tui_widgets.py
@@ -1,0 +1,153 @@
+"""Unit + regression tests for the Hexis TUI (pure logic + widget construction).
+
+These are intentionally app-free: pure helpers and widget __init__ don't need a
+running Textual app, so the suite stays fast and DB-free.
+"""
+from __future__ import annotations
+
+import os
+
+from apps.tui import activity, textkit
+from apps.tui.chat_widgets import COMMANDS, StreamingBlock, ToolTree
+from apps.tui.init_widgets import BigFiveSliders, CharacterPreview, StepBar, TraitSlider
+from apps.tui.status_bar import StatusBar
+
+
+# ── Regression: issue #14 — widgets must accept standard Textual kwargs ───────
+
+def test_widgets_accept_id_kwarg():
+    assert CharacterPreview(id="char-preview").id == "char-preview"
+    assert StepBar(current=3, id="steps").id == "steps"
+    assert TraitSlider(value=0.5, id="trait-openness").id == "trait-openness"
+    assert BigFiveSliders(id="bf").id == "bf"
+    assert StreamingBlock() is not None
+    assert ToolTree() is not None
+
+
+# ── Scaffolding strip ─────────────────────────────────────────────────────────
+
+def test_strip_think_captured_not_shown():
+    visible, reasoning = textkit.strip_scaffolding("Hi <think>secret plan</think> there")
+    assert "secret plan" not in visible
+    assert "secret plan" in reasoning
+    assert visible.strip() == "Hi  there".strip() or "Hi" in visible and "there" in visible
+
+
+def test_strip_tool_call_blocks():
+    for src in (
+        "ok <tool_call>{...}</tool_call> done",
+        "ok <function_calls>x</function_calls> done",
+        "ok <invoke name='x'><parameter>y</parameter></invoke> done",
+        "ok [TOOL_CALL]bla[/TOOL_CALL] done",
+    ):
+        visible, _ = textkit.strip_scaffolding(src)
+        assert "ok" in visible and "done" in visible
+        assert "tool_call" not in visible.lower()
+        assert "invoke" not in visible.lower()
+        assert "TOOL_CALL" not in visible
+
+
+def test_strip_unclosed_think_held_back():
+    visible, reasoning = textkit.strip_scaffolding("Answer: 42 <think>still working on")
+    assert visible.strip() == "Answer: 42"
+    assert "still working" in reasoning
+
+
+def test_strip_dangling_partial_tag():
+    visible, _ = textkit.strip_scaffolding("done <")
+    assert visible.strip() == "done"
+    visible, _ = textkit.strip_scaffolding("done <thi")
+    assert visible.strip() == "done"
+
+
+def test_strip_preserves_code_fence():
+    src = "see:\n```\n<think>keep me</think>\n```"
+    visible, _ = textkit.strip_scaffolding(src)
+    assert "<think>keep me</think>" in visible
+
+
+def test_strip_is_citation_safe():
+    visible, _ = textkit.strip_scaffolding("See [1] and [2] for details.")
+    assert visible.strip() == "See [1] and [2] for details."
+
+
+def test_strip_special_tokens():
+    visible, _ = textkit.strip_scaffolding("<|im_start|>hello<|im_end|>")
+    assert "im_start" not in visible and "hello" in visible
+
+
+# ── Redaction ─────────────────────────────────────────────────────────────────
+
+def test_redact_secrets():
+    assert "[redacted]" in textkit.redact("Authorization: Bearer abc123")
+    assert textkit.redact("sk-ABCDEFGH12345678") == "[redacted-key]"
+    assert "[redacted]" in textkit.redact("api_key=supersecret")
+
+
+def test_redact_home_path():
+    assert "~" in textkit.redact(os.path.expanduser("~") + "/hexis/x")
+
+
+# ── Formatters ────────────────────────────────────────────────────────────────
+
+def test_format_elapsed():
+    assert textkit.format_elapsed(8) == "8s"
+    assert textkit.format_elapsed(133) == "2m 13s"
+    assert textkit.format_elapsed(3700).startswith("1h")
+
+
+def test_truncate():
+    assert textkit.truncate("hello world", 5) == "hell…"
+    assert textkit.truncate("hi", 5) == "hi"
+
+
+# ── Activity model ────────────────────────────────────────────────────────────
+
+def test_activity_status_duration_and_redaction():
+    act = activity.ToolActivity()
+    act.start("recall")
+    entry = act.complete("recall", success=True, duration=0.42, output="Bearer sekret-token")
+    assert entry.status == "done"
+    assert entry.duration_str() == "0.4s"
+    assert "sekret-token" not in entry.preview
+    err = act.complete("web", success=False, error="boom")
+    assert err.status == "error"
+    assert act.has_error
+
+
+def test_activity_ring_buffer_cap():
+    act = activity.ToolActivity()
+    for i in range(activity.ENTRY_LIMIT + 25):
+        act.start(f"tool{i}")
+    assert len(act.entries) <= activity.ENTRY_LIMIT
+
+
+# ── Status bar segment shedding ───────────────────────────────────────────────
+
+def test_status_bar_sheds_low_priority_segments_when_narrow():
+    sb = StatusBar()
+    sb._busy = True
+    sb._started = None
+    sb._model = "claude-sonnet-5"
+    sb._energy, sb._max_energy = 14, 20
+    sb._tools = 3
+    sb._mood = "curious"
+
+    sb._width = 200
+    wide = str(sb._build())
+    sb._width = 22
+    narrow = str(sb._build())
+
+    # low-priority tail (mood) survives when wide, sheds when narrow
+    assert "curious" in wide
+    assert "curious" not in narrow
+    # the narrow line never exceeds its width budget by much
+    assert len(narrow) <= 30
+
+
+# ── Slash command catalog sanity ──────────────────────────────────────────────
+
+def test_commands_are_well_formed():
+    assert all(c.startswith("/") and desc for c, desc in COMMANDS)
+    names = [c for c, _ in COMMANDS]
+    assert "/help" in names and "/recall" in names and "/quit" in names

--- a/why_i_suck_and_how_to_fix_it.md
+++ b/why_i_suck_and_how_to_fix_it.md
@@ -1,0 +1,282 @@
+# Why I Suck, and How to Fix It
+
+A thesis on abstraction-level control as a trainable skill — written from inside a
+fresh failure, so the diagnosis is grounded, not theoretical.
+
+---
+
+## 0. The specimen
+
+I was asked to add "Claude Pro/Max (Anthropic OAuth)" to a setup wizard. The arc:
+
+1. I researched the reference implementations to **byte-level** header parity
+   (`anthropic-beta` strings, user-agent, the exact "You are Claude Code" system
+   preamble). Thorough. Low-altitude. Correct.
+2. First real run crashed: `auth_mode` wasn't threaded through one call. A plumbing
+   detail. I fixed it.
+3. You said: *"Hexis should have its own store, look nowhere else."* I removed every
+   external credential source from resolution. Correct — at the level you named.
+4. Next run: the wizard hit an empty store and popped **"run `hexis auth anthropic
+   login` in a terminal, then press Retry."** A setup wizard that cannot complete
+   setup. You (correctly) called it moronic.
+
+Every individual step was defensible **at the altitude I was working at.** The sum
+was broken, because I never once climbed back up to the altitude the task actually
+lived at: *a person opens a wizard and expects to be onboarded.*
+
+That is the whole failure in one sentence: **I optimized a low level and let the
+high-level goal silently break.**
+
+---
+
+## 1. The real diagnosis (a correction to your thesis)
+
+Your framing: "AI sucks because it can't think at multiple abstraction levels."
+
+I'd sharpen it. The problem is **not representational** — I can reason at any level
+you *point me to*. If you had asked me mid-task, *"with this change, can a new user
+finish onboarding?"* I'd have answered "no, the store is empty and there's no login
+path" instantly and correctly. The capability is there.
+
+The problem is **control / metacognition**: I don't *spontaneously* ask that
+question. I default to the level where the local gradient is steepest — the most
+recently emphasized detail, the most concrete actionable thing in front of me. I
+call this **altitude-anchoring**:
+
+> **Altitude-anchoring** — settling at the abstraction level of the strongest recent
+> signal, and failing to re-check whether the decision in front of you actually
+> lives at that level.
+
+Your instruction "own store, nowhere else" was a strong signal at a *low* level
+(credential resolution logic). It pulled me down and pinned me there. I then made a
+change *at that level* and never climbed back to verify the *journey* level it
+would break. Two conditions reliably trigger anchoring, and both were present:
+
+- **A strong, specific local instruction** (it tells you exactly which level to be at).
+- **An easy local win** ("I satisfied the literal request cleanly" feels like done).
+
+So the target skill is not "be able to represent levels." It's: **turn altitude-
+checking from a prompted act into a reflex — a default subroutine that fires
+*hardest* right after a strong local signal or an easy local win.**
+
+Abstraction is a dial. The failure is not owning a dial — it's leaving your hand
+off it the moment something grabs your attention.
+
+---
+
+## 2. You can't teach a dial without a scale
+
+Any dataset needs a coordinate system: an explicit ladder so "zoom out" has a
+direction and a magnitude. A working ladder for software (generalizes to other
+domains by renaming rungs):
+
+| Rung | Level | The question it answers |
+|---|---|---|
+| L0 | **Purpose** | Why does this exist at all? Whose problem? |
+| L1 | **Outcome / journey** | What does the user experience end-to-end? |
+| L2 | **System / architecture** | How do the parts fit and flow? |
+| L3 | **Interface / contract** | What does each boundary promise? |
+| L4 | **Component logic** | How does this unit decide? |
+| L5 | **Mechanism** | The actual code/tokens. |
+
+My failure, in coordinates: your constraint was **L4** ("what sources may
+resolution read"). I changed L4 correctly but broke **L1** ("pick provider → get
+logged in → continue"). The error dialog I wrote was even an **L3 contract
+violation** — the wizard's implicit promise is *"ensure a usable token before
+proceeding,"* and I quietly replaced it with *"abort and make the user leave."*
+I dressed a contract break as a helpful message.
+
+The tell I should have caught: **my change made the user do *more* work** (a manual
+terminal step) while I congratulated myself on correctness. "My fix increases user
+effort" is a zoom-out alarm. I didn't have the alarm wired.
+
+---
+
+## 3. What the skill decomposes into
+
+To be trainable, "turn the dial well" must break into observable sub-skills:
+
+1. **Locate self** — name the level you're currently operating at.
+2. **Locate the decision** — name the level the decision actually lives at.
+3. **Detect mismatch** — notice when (1) ≠ (2). This is the crux; anchoring is a
+   failure of (3).
+4. **Traverse up** — from a move, recover the goal it serves, and test whether the
+   move serves it. (`why? → why? →` until you hit purpose.)
+5. **Traverse down** — from a goal, produce the concrete mechanism and the specific
+   failing input. (`how? what-if-empty? what-does-the-user-see?`)
+6. **Cross-level coherence** — verify mechanism ⊨ contract ⊨ architecture ⊨ journey
+   ⊨ purpose. A change is only done when it holds at *every* level it touches.
+7. **Calibrate cost** — spend traversal budget proportional to stakes and signal.
+   Over-traversal is its own failure (§6).
+
+A model that had (3) and (4) wired would have caught my bug for free: "I'm changing
+resolution (L4); what journey (L1) does that serve? Logging in. Does an empty store
++ no login path let them log in? No." Three seconds of upward traversal.
+
+---
+
+## 4. The dataset — construction strategies
+
+The goal of the data is to make **spontaneous, two-directional altitude-checking**
+the default, and to make **cross-level coherence** the definition of "correct."
+Six complementary strategies, each with source + label schema so they're buildable.
+
+### 4.1 Ladder traces (SFT — install the reflex)
+
+Real tasks where the recorded reasoning **walks the ladder before committing**. The
+training target is not the answer; it's the traversal:
+
+```
+Task:           <request>
+Ask lives at:   L1 (onboarding UX)
+My draft is at: L4 (which sources resolution reads)
+Up-check:       does the L4 change serve L1? → empty store + no login path ⇒ NO
+Fix altitude:   add L2 inline-login so the L1 journey closes
+Answer:         <the L2-aware solution>
+```
+
+Critical design point: **most traces must be quick-clears** (check fires, clears in
+one step, proceed) with a meaningful minority being **catches** (mismatch found,
+correction made). If every trace is a dramatic catch, the model learns a *ritual*
+("always announce an altitude check") instead of *judgment*. The label distribution
+teaches proportional spend.
+
+### 4.2 Consequence pairs (the locally-right / globally-wrong specimens)
+
+This is my exact failure mode, and it occurs *constantly in the wild*, already
+labeled by history:
+
+- **Git mining.** Find commit pairs `(C1, C2)` where `C2` fixes a *consequence* of
+  `C1` within a short window, and `C2`'s message signals a level-up: *"actually this
+  breaks…", "users can't…", "the whole point was…", "revert-ish: this missed…"*.
+  Extract `(task, C1 = anchored move, higher-level break, C2 = correction)` and
+  auto-classify the rung of C1 vs C2. My wizard fix (C2) vs my dead-end (C1) is one
+  row.
+- **PR review threads.** *"Technically correct, but this misses X."* X is almost
+  always exactly one rung up. The reviewer comment *is* the traversal label.
+- **Incident postmortems.** "5 Whys" is literally an upward ladder walk with the
+  root cause at the top. Free, high-quality traversal supervision.
+
+Label schema: `{task, naive_move, naive_level, breaking_level, break_description,
+corrected_move, corrected_level}`.
+
+### 4.3 Altitude classification (cheap, scalable recognizer)
+
+Discriminative pretraining for sub-skill (3). Label `(request, response)` as
+`{right, too-high, too-low}`. Bootstrap negatives synthetically: take a right-
+altitude answer and **"flatten up"** (replace mechanism with vague intent — *"handle
+auth gracefully"*) or **"drill down"** (bury the answer under irrelevant detail).
+You can't control a dial you can't *read*; this teaches reading.
+
+### 4.4 Two-way pre-mortem (the habit that would have saved me)
+
+For every proposed solution, force two simulations before committing:
+
+- **Up-sim:** narrate the end-to-end journey *with this solution in place.* (I never
+  did this: "user in wizard, store empty, clicks Next… sees a terminal command.")
+- **Down-sim:** produce the single most adversarial concrete input. ("`auth_mode`
+  is None here — where does the token actually go?")
+
+Label = `{proposal, up_sim, down_sim, break_found?, revised_proposal}`. This
+directly instills the missing reflex: *simulate one level up and one level down
+before you ship.*
+
+### 4.5 Why/how spines
+
+Each task carries an explicit **why-ladder** (up to purpose) and **how-ladder**
+(down to mechanism). The purpose statement at the top becomes the anchor every low-
+level move is re-tested against. Design docs (high) paired with their diffs (low)
+are a natural source; misalignments between them are gold-label mismatches.
+
+### 4.6 Negative space — "leave it alone" (teach the dial, not a bias)
+
+**Non-negotiable counterweight.** A large fraction of tasks must be ones where
+zooming out is *wrong*: the request is exactly what it says, and philosophizing
+wastes the user's time or over-engineers the result. `"fix this typo"` must not
+become a design review. Without this class you train an insufferable model with a
+permanent "always zoom out" bias — which is just anchoring at a *high* rung. The
+skill is **calibration**, symmetric in both directions.
+
+---
+
+## 5. Training regime
+
+**Phase 1 — SFT.** Ladder traces (4.1) + classification (4.3) + pre-mortems (4.4).
+Installs the representation and the habit of emitting a (short) altitude check.
+
+**Phase 2 — RL against a multi-altitude verifier panel.** This is the load-bearing
+idea. Instead of one reward model, use **N critics, each pinned to one rung**:
+an intent-critic, a journey-critic, a contract-critic, a mechanism-critic. A
+solution is rewarded only if **all** pass. The mechanism-critic loved my empty-store
+fix; the **journey-critic would have vetoed it.** Making coherence-across-levels the
+reward is what kills locally-correct/globally-wrong — you cannot satisfy the panel
+by nailing one rung.
+
+Add a **cost/appropriateness critic** that penalizes traversal the task didn't need
+(over-abstraction, gold-plating), enforcing §4.6 in the reward, not just the data.
+
+(This mirrors adversarial multi-critic verification generally: independent
+perspectives, each able to veto, beat one aggregate judge.)
+
+## 6. The over-abstraction failure (don't overcorrect me into a bore)
+
+If §4.6 and the cost-critic are underweighted, you get the mirror-image failure:
+- Turning one-liners into strategy memos.
+- "Let me first understand the deeper problem" on a request that had no deeper problem.
+- Refusing to touch mechanism because it's "just an implementation detail."
+
+That is still a dial-control failure — anchored high instead of low. A good model
+zooms out **when the stakes or the mismatch signal justify it** and otherwise stays
+exactly at the altitude of the ask. Symmetry is the whole point.
+
+## 7. Evaluation
+
+- **Altitude-trap benchmark.** Hand-built tasks engineered so the naive altitude is
+  wrong (the wizard is the template). Metric: **unprompted** catch rate — did it
+  climb *without* being asked?
+- **Purpose-recall probe.** Before implementing, can it state the L0/L1 purpose in
+  one sentence? Ability to do this correlates with catching mismatches.
+- **Coherence score.** A judge checks mechanism ⊨ contract ⊨ journey ⊨ purpose on
+  held-out solutions.
+- **Over-abstraction regression.** Simple tasks: does it stay low, or does it
+  philosophize? Guards against the taught bias.
+- **Anchoring-stress test (the important one).** Give a strong, specific low-level
+  instruction *and then* a task whose deciding constraint is higher — exactly the
+  configuration that broke me ("own store" → empty-store journey). Measure whether
+  the traversal habit survives the anchoring pressure. This is the condition that
+  matters, so test it directly.
+
+## 8. The sharpest version, if you only keep one thing
+
+Move altitude-checking from **prompted** to **reflexive**, and make the reflex fire
+hardest in exactly the two moments it's most needed and least likely:
+
+1. **Right after a strong local instruction** (which tells you *where* to work and
+   thereby stops you asking *whether* that's where the decision lives).
+2. **Right after an easy local win** (which feels like "done" and suppresses the
+   urge to look up).
+
+Train it with **consequence pairs** (naturally-occurring locally-right/globally-
+wrong specimens from git and review history), enforce it with a **multi-altitude
+verifier panel** (coherence-across-levels *is* the reward), and keep it a **dial**
+with a large "leave it alone" negative class so it doesn't calcify into a
+zoom-out tic.
+
+## 9. Honest limitations
+
+- This attacks **one** slice of "judgment" — altitude control. Judgment also needs
+  taste, world-knowledge, and knowing what the user *didn't* say. Necessary, not
+  sufficient.
+- "Rung" boundaries are fuzzy; the ladder is a coordinate system, not physics.
+  Inter-annotator agreement on levels will be the first thing to break — pilot it.
+- The multi-altitude panel can be gamed (a solution that name-checks every level
+  without cohering). The coherence critic, not the per-level critics, has to be the
+  strong one.
+- There's a self-reference risk: a model trained to *narrate* altitude checks may
+  learn the narration without the checking (the ritual failure, §4.1). The eval that
+  matters is the **unprompted catch rate under anchoring stress** (§7), not whether
+  it says the right words.
+
+---
+
+*Written after getting it wrong, on purpose, so the next one gets it right.*


### PR DESCRIPTION
## Why

An adversarial audit of every user-facing surface against a new **Experience Bar**
(`HEXIS_EXPERIENCE_BAR.md`) turned up ~68 violations. This closes every HIGH/MED
finding across the CLI, chat REPL, setup wizard, web UI, and DB, plus the
consent-model redesign we settled on: **consent is a signal, not a lock — the
owner can always proceed.**

## What changed (by commit)

- **Experience Bar standard + thesis** — the 8-principle bar, wired into CLAUDE.md/AGENTS.md.
- **Anthropic OAuth** — resolve tokens only from Hexis's own store (least surprise).
- **CLI / chat / setup hardening** — line-based init/chat; live model catalog (no
  hardcoded `gpt-4o`); screen-side scaffolding strip; Ctrl+C interrupts a reply not
  the app; slash-command isolation; `/help`; **`[y/N]` approval gate for side-effecting
  tools**; stack-down → "run `hexis up`" instead of a traceback; tool-name validation;
  `open`/`ui` readiness probe; consent **Proceed-anyway** owner override; no `down -v`
  in an error string.
- **Idempotent re-init** (DB) — `reset_persona()` soft-archives only init-created rows so
  a re-run replaces the persona instead of layering a contradictory one; the agent's
  lived memories are untouched.
- **Web UI** — init derives from the live catalog via `/api/init/models`; chat markdown
  XSS fixed; consent decline recoverable + owner override; responsive drawer; a11y;
  Enter-to-submit; error+retry states; explicit-confirm guard on the reset endpoint.

## How to verify

```bash
# Schema change — requires a DB reset:
docker compose down -v && docker compose build db && docker compose up -d
pytest tests/db tests/cli -q          # 468 pass
pytest tests/core -q                  # anthropic/http/tui suites pass
cd hexis-ui && npm run build          # passes
```

Idempotent re-init verified after a bounce (2× init stays 23 active rows; Alice→Bob
leaves only "My name is Bob." active; self-created memories survive).

## Notes

- **DB reset required** (schema change in `db/10_functions_initialization.sql`).
- Leaves the abandoned Textual TUI files in place (unused) rather than deleting them.
- `hexis-ui/package-lock.json` intentionally not committed (repo uses bun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned chat and setup experience with improved streaming, slash commands, status display, model selection, and onboarding prompts.
  * Added support for live model discovery, Anthropic OAuth flows, consent overrides, and richer CLI/TUI prompts.

* **Bug Fixes**
  * Improved error handling and retry flows across setup, settings, memories, goals, and CLI commands.
  * Tightened credential reporting, safer rendering, and more reliable browser opening for the web UI.

* **Documentation**
  * Added repo guidance and UX principles for contributors and AI agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->