### PR TITLE
Repair broken external_calls tools with a DB-native outbox (Phase 6)

### DIFF
--- a/core/tools/memory.py
+++ b/core/tools/memory.py
@@ -1018,19 +1018,17 @@ class QueueUserMessageHandler(ToolHandler):
         arguments: dict[str, Any],
         context: ToolExecutionContext,
     ) -> ToolResult:
-        import json
-
         message = arguments["message"]
         intent = arguments.get("intent")
 
         try:
+            # Durably enqueue in the DB-native outbox; the maintenance worker
+            # drains it to the RabbitMQ outbox for delivery.
             async with context.registry.pool.acquire() as conn:
-                await conn.execute(
-                    """
-                    INSERT INTO external_calls (call_type, input, status)
-                    VALUES ('outbox_message', $1::jsonb, 'pending')
-                    """,
-                    json.dumps({"message": message, "intent": intent}),
+                await conn.fetchval(
+                    "SELECT queue_outbox_message($1::text, $2::text, 'tool')",
+                    message,
+                    intent,
                 )
 
             return ToolResult.success_result(

--- a/core/tools/web.py
+++ b/core/tools/web.py
@@ -518,56 +518,39 @@ URL: {url}
 
         prompt += f"\nContent:\n{content}"
 
-        # Use external_calls to queue LLM request
+        # Summarize with a direct in-process LLM call (the configured provider).
         try:
-            import json
+            from core.llm import chat_completion
+            from core.llm_config import load_llm_config
 
-            async with context.registry.pool.acquire() as conn:
-                # Queue the summarization request
-                call_id = await conn.fetchval(
-                    """
-                    INSERT INTO external_calls (call_type, input, status)
-                    VALUES ('llm_completion', $1::jsonb, 'pending')
-                    RETURNING id
-                    """,
-                    json.dumps({
-                        "prompt": prompt,
-                        "max_tokens": 500,
-                        "purpose": "web_summarize",
-                    }),
+            try:
+                llm_config = await load_llm_config(context.registry.pool, preference="cheap")
+            except Exception:
+                llm_config = await load_llm_config(context.registry.pool)
+
+            response = await chat_completion(
+                messages=[{"role": "user", "content": prompt}],
+                **{**llm_config, "max_tokens": 500},
+            )
+
+            summary = response.get("content", "") if response else ""
+            if isinstance(summary, list):  # some providers return content blocks
+                summary = "".join(
+                    b.get("text", "")
+                    for b in summary
+                    if isinstance(b, dict) and b.get("type") == "text"
                 )
-
-            # Wait for completion (with timeout)
-            import asyncio
-            for _ in range(30):  # 30 second timeout
-                async with context.registry.pool.acquire() as conn:
-                    result = await conn.fetchrow(
-                        "SELECT status, output, error FROM external_calls WHERE id = $1",
-                        call_id,
-                    )
-                if result["status"] == "completed":
-                    output_data = json.loads(result["output"]) if result["output"] else {}
-                    summary = output_data.get("text", "")
-                    return ToolResult.success_result(
-                        output={
-                            "url": url,
-                            "title": title,
-                            "summary": summary,
-                            "focus": focus,
-                        },
-                        display_output=f"Summary of {title or url}:\n{summary}",
-                    )
-                elif result["status"] == "failed":
-                    return ToolResult.error_result(
-                        result["error"] or "Summarization failed",
-                        ToolErrorType.EXECUTION_FAILED,
-                    )
-                await asyncio.sleep(1)
-
+            summary = (summary or "").strip()
+            if not summary:
                 return ToolResult.error_result(
-                    "Summarization timed out",
-                    ToolErrorType.TIMEOUT,
+                    "Summarization returned an empty result",
+                    ToolErrorType.EXECUTION_FAILED,
                 )
+
+            return ToolResult.success_result(
+                output={"url": url, "title": title, "summary": summary, "focus": focus},
+                display_output=f"Summary of {title or url}:\n{summary}",
+            )
 
         except Exception as e:
             logger.exception("Web summarize failed")

--- a/db/42_functions_outbox.sql
+++ b/db/42_functions_outbox.sql
@@ -1,0 +1,119 @@
+-- DB-native transactional outbox for agent-initiated user messages.
+--
+-- Previously the queue_user_message tool INSERTed into a non-existent
+-- `external_calls` table (it always threw), and the agentic heartbeat loop had
+-- no delivery path for tool-produced messages at all. This gives tools a real
+-- place to durably queue a message; the maintenance worker drains it to the
+-- RabbitMQ outbox using the same envelope shape as heartbeat outbox messages.
+SET search_path = public, ag_catalog, "$user";
+
+CREATE TABLE IF NOT EXISTS outbox_messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    envelope JSONB NOT NULL,   -- build_user_message() shape: {message_id, kind, payload}
+    source TEXT NOT NULL DEFAULT 'tool',
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'publishing', 'published', 'failed')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    claimed_at TIMESTAMPTZ,
+    published_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_messages_pending
+    ON outbox_messages (created_at)
+    WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_outbox_messages_publishing
+    ON outbox_messages (claimed_at)
+    WHERE status = 'publishing';
+
+-- Durably enqueue a user-facing message. Returns the row id.
+CREATE OR REPLACE FUNCTION queue_outbox_message(
+    p_message TEXT,
+    p_intent TEXT DEFAULT NULL,
+    p_source TEXT DEFAULT 'tool'
+) RETURNS UUID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    new_id UUID;
+BEGIN
+    IF NULLIF(btrim(p_message), '') IS NULL THEN
+        RAISE EXCEPTION 'outbox message is required';
+    END IF;
+    INSERT INTO outbox_messages (envelope, source)
+    VALUES (build_user_message(p_message, p_intent), COALESCE(NULLIF(p_source, ''), 'tool'))
+    RETURNING id INTO new_id;
+    RETURN new_id;
+END;
+$$;
+
+-- Claim pending messages (and reclaim stale 'publishing' rows whose publisher
+-- died) for delivery. Marks them 'publishing' and returns [{id, envelope}].
+CREATE OR REPLACE FUNCTION claim_pending_outbox(
+    p_limit INT DEFAULT 50,
+    p_claim_timeout_s INT DEFAULT 120
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    result JSONB;
+BEGIN
+    WITH candidate AS (
+        SELECT id
+        FROM outbox_messages
+        WHERE status = 'pending'
+           OR (status = 'publishing'
+               AND claimed_at < CURRENT_TIMESTAMP - make_interval(secs => GREATEST(COALESCE(p_claim_timeout_s, 120), 1)))
+        ORDER BY created_at
+        FOR UPDATE SKIP LOCKED
+        LIMIT GREATEST(COALESCE(p_limit, 50), 1)
+    ),
+    claimed AS (
+        UPDATE outbox_messages o
+        SET status = 'publishing', claimed_at = CURRENT_TIMESTAMP
+        FROM candidate
+        WHERE o.id = candidate.id
+        RETURNING o.id, o.envelope, o.created_at
+    )
+    SELECT COALESCE(
+        jsonb_agg(jsonb_build_object('id', id::text, 'envelope', envelope) ORDER BY created_at),
+        '[]'::jsonb)
+    INTO result
+    FROM claimed;
+    RETURN result;
+END;
+$$;
+
+-- Mark successfully-published messages done.
+CREATE OR REPLACE FUNCTION mark_outbox_published(p_ids UUID[])
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    n INT;
+BEGIN
+    UPDATE outbox_messages
+    SET status = 'published', published_at = CURRENT_TIMESTAMP
+    WHERE id = ANY(COALESCE(p_ids, ARRAY[]::UUID[]))
+      AND status = 'publishing';
+    GET DIAGNOSTICS n = ROW_COUNT;
+    RETURN n;
+END;
+$$;
+
+-- Return claimed-but-unpublished messages to 'pending' so they retry promptly
+-- (rather than waiting for the reclaim timeout).
+CREATE OR REPLACE FUNCTION requeue_outbox(p_ids UUID[])
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    n INT;
+BEGIN
+    UPDATE outbox_messages
+    SET status = 'pending', claimed_at = NULL
+    WHERE id = ANY(COALESCE(p_ids, ARRAY[]::UUID[]))
+      AND status = 'publishing';
+    GET DIAGNOSTICS n = ROW_COUNT;
+    RETURN n;
+END;
+$$;

--- a/services/worker_service.py
+++ b/services/worker_service.py
@@ -395,6 +395,28 @@ class MaintenanceWorker:
         if self.bridge:
             await self.bridge.publish_outbox_payloads(messages)
 
+    async def _run_outbox_delivery(self) -> None:
+        """Drain the DB-native outbox (tool-queued user messages) to RabbitMQ.
+
+        publish_outbox_payloads publishes in order and returns the count that
+        succeeded (stopping at the first failure), so mark that prefix published
+        and requeue the rest for the next tick.
+        """
+        if not self.pool or not self.bridge:
+            return
+        async with self.pool.acquire() as conn:
+            raw = await conn.fetchval("SELECT claim_pending_outbox($1::int)", 50)
+            claimed = json.loads(raw) if isinstance(raw, str) else (raw or [])
+            if not claimed:
+                return
+            ids = [c["id"] for c in claimed]
+            envelopes = [c["envelope"] for c in claimed]
+            published = await self.bridge.publish_outbox_payloads(envelopes)
+            if published > 0:
+                await conn.fetchval("SELECT mark_outbox_published($1::uuid[])", ids[:published])
+            if published < len(ids):
+                await conn.fetchval("SELECT requeue_outbox($1::uuid[])", ids[published:])
+
     async def _run_scheduled_tasks(self) -> None:
         if not self.pool:
             return
@@ -502,6 +524,7 @@ class MaintenanceWorker:
                         continue
                     if self.bridge:
                         await self.bridge.poll_inbox_messages()
+                    await self._run_outbox_delivery()
                     await self._run_scheduled_tasks()
                     await self._run_maintenance_if_due()
                     await self._run_subconscious_if_due()

--- a/tests/core/test_tools_hardening.py
+++ b/tests/core/test_tools_hardening.py
@@ -119,32 +119,9 @@ async def test_execute_batch_parallel_energy_budget(monkeypatch):
 
 @pytest.mark.asyncio(loop_scope="session")
 @pytest.mark.core
-async def test_web_summarize_releases_connections(monkeypatch):
-    class DummyConn:
-        async def fetchval(self, *args, **kwargs):
-            return "call_id"
-
-        async def fetchrow(self, *args, **kwargs):
-            return {"status": "completed", "output": json.dumps({"text": "summary"}), "error": None}
-
-    class DummyAcquire:
-        def __init__(self, pool):
-            self.pool = pool
-
-        async def __aenter__(self):
-            self.pool.acquire_calls += 1
-            return DummyConn()
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class DummyPool:
-        def __init__(self):
-            self.acquire_calls = 0
-
-        def acquire(self):
-            return DummyAcquire(self)
-
+async def test_web_summarize_uses_direct_llm(monkeypatch):
+    """web_summarize summarizes via a single in-process LLM call (the broken
+    external_calls queue+poll path is gone)."""
     dummy_trafilatura = types.SimpleNamespace(
         fetch_url=lambda url: "<html></html>",
         extract=lambda downloaded, include_tables=True: "content",
@@ -152,12 +129,25 @@ async def test_web_summarize_releases_connections(monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "trafilatura", dummy_trafilatura)
 
-    registry = SimpleNamespace(pool=DummyPool())
+    async def _fake_load_llm_config(pool, **kwargs):
+        return {"provider": "openai", "model": "gpt-4o", "endpoint": None, "api_key": "t"}
+
+    captured: dict = {}
+
+    async def _fake_chat_completion(**kwargs):
+        captured.update(kwargs)
+        return {"content": "A concise summary.", "raw": None}
+
+    monkeypatch.setattr("core.llm_config.load_llm_config", _fake_load_llm_config)
+    monkeypatch.setattr("core.llm.chat_completion", _fake_chat_completion)
+
     context = ToolExecutionContext(tool_context=ToolContext.CHAT, call_id="x")
-    context.registry = registry
+    context.registry = SimpleNamespace(pool=SimpleNamespace())  # only handed to load_llm_config
 
     handler = WebSummarizeHandler()
     result = await handler.execute({"url": "http://example.com"}, context)
 
     assert result.success is True
-    assert registry.pool.acquire_calls >= 2
+    assert result.output["summary"] == "A concise summary."
+    assert captured["max_tokens"] == 500
+    assert captured["messages"][0]["role"] == "user"

--- a/tests/db/test_outbox.py
+++ b/tests/db/test_outbox.py
@@ -1,0 +1,94 @@
+"""Tests for the DB-native transactional outbox (db/42_functions_outbox.sql).
+
+Replaces the broken `INSERT INTO external_calls` path in the queue_user_message
+tool: tools durably enqueue via queue_outbox_message; the maintenance worker
+claims → publishes → marks published (or requeues on failure).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = [pytest.mark.asyncio(loop_scope="session")]
+
+
+def _j(v):
+    return json.loads(v) if isinstance(v, str) else v
+
+
+async def test_queue_claim_publish_lifecycle(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            mid = await conn.fetchval(
+                "SELECT queue_outbox_message($1::text, $2::text, 'tool')",
+                "Hello Eric, checking in.", "status",
+            )
+            assert mid is not None
+
+            # Row is pending with a build_user_message envelope.
+            row = await conn.fetchrow("SELECT status, envelope FROM outbox_messages WHERE id = $1", mid)
+            assert row["status"] == "pending"
+            env = _j(row["envelope"])
+            assert env["kind"] == "user"
+            assert env["payload"]["message"] == "Hello Eric, checking in."
+            assert env["payload"]["intent"] == "status"
+
+            # Claim marks it publishing and returns the envelope for delivery.
+            claimed = _j(await conn.fetchval("SELECT claim_pending_outbox(50)"))
+            assert [c["id"] for c in claimed] == [str(mid)]
+            assert claimed[0]["envelope"]["payload"]["message"] == "Hello Eric, checking in."
+            assert await conn.fetchval("SELECT status FROM outbox_messages WHERE id = $1", mid) == "publishing"
+
+            # A second claim returns nothing (already publishing, not stale).
+            assert _j(await conn.fetchval("SELECT claim_pending_outbox(50)")) == []
+
+            # Marking published closes it out.
+            n = await conn.fetchval("SELECT mark_outbox_published($1::uuid[])", [mid])
+            assert n == 1
+            assert await conn.fetchval("SELECT status FROM outbox_messages WHERE id = $1", mid) == "published"
+        finally:
+            await tr.rollback()
+
+
+async def test_requeue_returns_to_pending(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            mid = await conn.fetchval("SELECT queue_outbox_message('retry me', NULL, 'tool')")
+            await conn.fetchval("SELECT claim_pending_outbox(50)")  # -> publishing
+            n = await conn.fetchval("SELECT requeue_outbox($1::uuid[])", [mid])
+            assert n == 1
+            assert await conn.fetchval("SELECT status FROM outbox_messages WHERE id = $1", mid) == "pending"
+            # It is claimable again.
+            claimed = _j(await conn.fetchval("SELECT claim_pending_outbox(50)"))
+            assert [c["id"] for c in claimed] == [str(mid)]
+        finally:
+            await tr.rollback()
+
+
+async def test_stale_publishing_is_reclaimed(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            mid = await conn.fetchval("SELECT queue_outbox_message('stuck', NULL, 'tool')")
+            await conn.fetchval("SELECT claim_pending_outbox(50)")  # -> publishing
+            # Simulate a publisher that died mid-flight.
+            await conn.execute(
+                "UPDATE outbox_messages SET claimed_at = CURRENT_TIMESTAMP - interval '10 minutes' WHERE id = $1",
+                mid,
+            )
+            reclaimed = _j(await conn.fetchval("SELECT claim_pending_outbox(50, 60)"))
+            assert [c["id"] for c in reclaimed] == [str(mid)]
+        finally:
+            await tr.rollback()
+
+
+async def test_empty_message_rejected(db_pool):
+    async with db_pool.acquire() as conn:
+        with pytest.raises(Exception):
+            await conn.fetchval("SELECT queue_outbox_message('   ', NULL, 'tool')")


### PR DESCRIPTION
## Repair the two broken `external_calls` tools with a DB-native outbox

Both `queue_user_message` and `web_summarize` `INSERT`ed into an `external_calls` table **that does not exist** — they threw at runtime on every call. This repairs both, and closes a real gap: the agentic heartbeat loop had **no delivery path** for tool-produced user messages.

### Changes

- **`web_summarize`** now summarizes with a single in-process LLM call (`load_llm_config` + `chat_completion`, the `humanizer.py` pattern) instead of queuing to the missing table and polling. Also drops a latent bug (the timeout `return` was inside the poll loop).
- **`queue_user_message`** durably enqueues via a new **DB-native transactional outbox** (`db/42_functions_outbox.sql`): `queue_outbox_message` → `outbox_messages` table. The **maintenance worker** drains it — `claim_pending_outbox` → `bridge.publish_outbox_payloads` → `mark_outbox_published`, with `requeue_outbox` on failure and stale-claim reclaim. The envelope reuses `build_user_message`, so it's the same shape the heartbeat/scheduled paths already publish.

### Why an outbox table

Outbox messages otherwise flow only as JSONB arrays in heartbeat/scheduled-task result payloads. A mid-loop tool has nowhere to put one — and the agentic `finalize_heartbeat` returns `outbox_messages: []`. The table gives tools a durable, DB-owned queue that the worker delivers, independent of the loop's payload threading.

### Verification

```
pytest tests/db/test_outbox.py tests/core/test_tools_hardening.py -q
```

- `test_outbox.py` (4): queue → claim → publish, requeue, stale-publishing reclaim, empty-message rejection.
- `test_tools_hardening.py`: `web_summarize` updated to the direct-LLM path.
- `queue_user_message` verified end-to-end against a live DB (queues a real `outbox_messages` row).

**DB reset** needed to pick up `db/42` (new table + functions): `docker-compose down -v && docker-compose build db && docker-compose up -d`.

### Not included

The other Phase 6 item — moving `finalize_heartbeat`'s inline SQL into a function — collides with an existing legacy SQL `finalize_heartbeat` (different signature) and touches the autonomous-heartbeat path for modest gain. Left as an optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more reliable message queue behind the scenes, improving delivery handling for queued user messages.
  * Updated web summarization to run directly and return results faster with clearer output details.
  * Added ongoing background processing to publish queued items automatically.

* **Bug Fixes**
  * Improved handling for empty or failed summaries.
  * Added recovery for stuck or outdated queued items.

* **Tests**
  * Expanded coverage for queueing, publishing, re-queuing, and summarization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->