### PR TITLE
Fix embedding cold-start timeout (5s -> 9s, config-driven)

### DIFF
--- a/db/00_tables.sql
+++ b/db/00_tables.sql
@@ -447,7 +447,8 @@ INSERT INTO config (key, value, description) VALUES
     ('embedding.model_id', to_jsonb(COALESCE(NULLIF(current_setting('app.embedding_model_id', true), ''), 'embeddinggemma:300m-qat-q4_0')), 'Embedding model id for Ollama / custom services'),
     ('embedding.dimension', to_jsonb(COALESCE(NULLIF(current_setting('app.embedding_dimension', true), ''), '768')::int), 'Embedding vector dimension'),
     ('embedding.retry_seconds', '30'::jsonb, 'Total seconds to retry embedding requests'),
-    ('embedding.retry_interval_seconds', '1.0'::jsonb, 'Seconds between retry attempts')
+    ('embedding.retry_interval_seconds', '1.0'::jsonb, 'Seconds between retry attempts'),
+    ('embedding.http_timeout_ms', '9000'::jsonb, 'Per-request HTTP timeout (ms) for embedding calls; must exceed the server cold model-load time (~8s for Ollama) so a request rides through a cold load instead of aborting it')
 ON CONFLICT (key) DO NOTHING;
 -- Note: embedding_dimension runs during schema init; avoid helpers defined later.
 CREATE OR REPLACE FUNCTION embedding_dimension()

--- a/db/03_functions_helpers.sql
+++ b/db/03_functions_helpers.sql
@@ -105,6 +105,7 @@ RETURNS vector[] AS $$
 	    start_ts TIMESTAMPTZ;
 	    retry_seconds INT;
 	    retry_interval_seconds FLOAT;
+	    http_timeout_ms INT;
 	    last_error TEXT;
 	    result vector[];
 	    missing_texts TEXT[] := ARRAY[]::text[];
@@ -182,6 +183,15 @@ RETURNS vector[] AS $$
 	        (SELECT (value #>> '{}')::float FROM config WHERE key = 'embedding.retry_interval_seconds'),
 	        1.0
 	    );
+	    -- Bound each HTTP attempt above the embedding server's cold model-load
+	    -- time (~8s for Ollama). The pgsql-http default (5s) is shorter, so the
+	    -- first embed after an idle unload aborts mid-load -- which cancels the
+	    -- load -- and never recovers within retry_seconds. 9s rides it through.
+	    http_timeout_ms := COALESCE(
+	        (SELECT (value #>> '{}')::int FROM config WHERE key = 'embedding.http_timeout_ms'),
+	        9000
+	    );
+	    PERFORM http_set_curlopt('CURLOPT_TIMEOUT_MS', http_timeout_ms::text);
 	    max_batch_size := COALESCE(
 	        NULLIF((SELECT (value #>> '{}')::int FROM config WHERE key = 'embedding.max_batch_size'), 0),
 	        total  -- send all at once; let the embedding server handle internal batching


### PR DESCRIPTION
get_embedding used the pgsql-http default **5s** per-request timeout, but Ollama's cold model-load is **~8s** after an idle unload. A 5s abort cancels the in-flight load, so the first embed after idle failed with `Embedding service not available after 30 seconds` — cascading into `create_memory` and graph operations (the intermittent `tests/db` failures).

**Fix:** config-driven per-request timeout `embedding.http_timeout_ms` (default **9000ms**), applied in `get_embedding` via `http_set_curlopt(CURLOPT_TIMEOUT_MS, ...)`, so one request rides through the cold load.

**Verified:** force-unloaded the model, embed succeeds; `http_list_curlopt` shows `CURLOPT_TIMEOUT_MS=9000`; clean `down -v && build db && up` seeds the config and applies from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding request handling so lookups are less likely to fail during slower model startup periods.
  * Added a configurable timeout for embedding requests to make the feature more reliable under load.
  * Updated the default settings to better support embedding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->