### PR TITLE
Sub-knowledge-graph as primary reasoning path (Phases 1-3)

### DIFF
--- a/core/cognitive_memory_api.py
+++ b/core/cognitive_memory_api.py
@@ -95,6 +95,17 @@ class RecallResult:
     query: str
 
 
+# Default edge types for the chat reasoning subgraph: the *semantic* relations
+# that carry reasoning structure. Excludes hub-forming structural/temporal edges
+# (IN_EPISODE, MEMBER_OF, CLUSTER_*, goal-tree edges) that would over-connect the
+# view — every co-occurring memory linking through one episode/cluster node. The
+# substrate still stores those; the explore_subgraph tool can request any type.
+REASONING_EDGE_TYPES = [
+    "CAUSES", "SUPPORTS", "CONTRADICTS", "DERIVED_FROM",
+    "CONTESTED_BECAUSE", "INSTANCE_OF", "ASSOCIATED", "TEMPORAL_NEXT",
+]
+
+
 @dataclass(frozen=True)
 class HydratedContext:
     memories: list[Memory]
@@ -104,6 +115,10 @@ class HydratedContext:
     emotional_state: dict[str, Any] | None
     goals: dict[str, Any] | None
     urgent_drives: list[dict[str, Any]]
+    # Dynamic sub-knowledge-graph seeded from the recalled memories: the typed
+    # {nodes, edges} structure (supports/contradicts/causes/...) among + around
+    # them. None when disabled or nothing was recalled.
+    subgraph: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -218,6 +233,10 @@ class CognitiveMemory:
         include_emotional_state: bool = True,
         include_goals: bool = False,
         include_drives: bool = True,
+        include_subgraph: bool = True,
+        subgraph_depth: int = 2,
+        subgraph_budget: int = 40,
+        subgraph_rel_types: list[str] | None = None,
         session_id: UUID | str | None = None,
     ) -> HydratedContext:
         """
@@ -256,6 +275,24 @@ class CognitiveMemory:
         goals = ctx.get("goals") if include_goals else None
         urgent_drives = ctx.get("urgent_drives", []) if include_drives else []
 
+        # Seed the dynamic sub-knowledge-graph from the recalled memories. Runs
+        # after recall (it depends on the recalled ids), as one small round-trip.
+        subgraph = None
+        if include_subgraph and memories:
+            seed_ids = [m.id for m in memories]
+            # Default to the semantic reasoning edges (curated); callers can pass
+            # an explicit list (incl. structural types) to override.
+            rel_types = subgraph_rel_types if subgraph_rel_types is not None else REASONING_EDGE_TYPES
+            try:
+                async with self._pool.acquire() as conn:
+                    sg_row = await conn.fetchval(
+                        "SELECT build_context_subgraph($1::uuid[], $2, $3::text[], $4)",
+                        seed_ids, subgraph_depth, rel_types, subgraph_budget,
+                    )
+                subgraph = _coerce_json(sg_row)
+            except Exception:
+                subgraph = None  # advisory: never fail hydration on subgraph assembly
+
         return HydratedContext(
             memories=memories,
             partial_activations=partial,
@@ -264,6 +301,7 @@ class CognitiveMemory:
             emotional_state=dict(emotional_state) if isinstance(emotional_state, dict) else None,
             goals=dict(goals) if isinstance(goals, dict) else None,
             urgent_drives=list(urgent_drives) if isinstance(urgent_drives, list) else [],
+            subgraph=subgraph if isinstance(subgraph, dict) else None,
         )
 
     async def hydrate_batch(
@@ -1447,6 +1485,32 @@ class CognitiveMemorySync:
         return self._loop.run_until_complete(self._async.record_ingestion_receipts(items))
 
 
+def _format_subgraph(subgraph: dict[str, Any] | None, *, max_edges: int = 20) -> str | None:
+    """Render a build_context_subgraph result ({nodes, edges}) as compact markdown:
+    one 'A  —rel→  B' line per typed edge, using node labels. None if no structure."""
+    if not isinstance(subgraph, dict):
+        return None
+    nodes = subgraph.get("nodes") or []
+    edges = subgraph.get("edges") or []
+    if not edges:
+        return None
+    label: dict[tuple[Any, Any], str] = {}
+    for n in nodes:
+        if isinstance(n, dict):
+            lbl = str(n.get("label") or n.get("id") or "").strip()
+            label[(n.get("type"), n.get("id"))] = lbl[:80]
+    lines: list[str] = []
+    for e in sorted(
+        (e for e in edges if isinstance(e, dict)),
+        key=lambda e: (str(e.get("rel", "")), str(e.get("src_id", ""))),
+    )[:max_edges]:
+        s = label.get((e.get("src_type"), e.get("src_id")), e.get("src_id"))
+        d = label.get((e.get("dst_type"), e.get("dst_id")), e.get("dst_id"))
+        rel = str(e.get("rel") or "related").lower()
+        lines.append(f"- {s}  —{rel}→  {d}")
+    return "\n".join(lines) if lines else None
+
+
 def format_context_for_prompt(context: HydratedContext, *, max_memories: int = 5, max_partials: int = 3) -> str:
     parts: list[str] = []
 
@@ -1484,6 +1548,12 @@ def format_context_for_prompt(context: HydratedContext, *, max_memories: int = 5
                     elif kind:
                         src_kind = f", source: {kind}"
                 parts.append(f"- {m.content}{score}{trust}{src_kind}")
+
+    subgraph_md = _format_subgraph(context.subgraph)
+    if subgraph_md:
+        parts.append("\n## Knowledge Subgraph")
+        parts.append("How the recalled memories connect (typed links among + around them):")
+        parts.append(subgraph_md)
 
     if context.partial_activations:
         parts.append("\n## Vague Recollections (tip-of-tongue)")

--- a/db/05_functions_provenance_trust.sql
+++ b/db/05_functions_provenance_trust.sql
@@ -1170,6 +1170,9 @@ BEGIN
             p_category,
             p_stability
         );
+        PERFORM upsert_memory_edge('self', 'self', 'HAS_BELIEF', 'memory', new_memory_id::text,
+                                   p_stability, p_category, NULL,
+                                   jsonb_build_object('category', p_category, 'stability', p_stability));
     EXCEPTION WHEN OTHERS THEN NULL;
     END;
 
@@ -1636,11 +1639,13 @@ BEGIN
         p_relationship_type,
         CASE WHEN p_properties = '{}'::jsonb 
              THEN '' 
-             ELSE format('{%s}', 
+             ELSE format('{%s}',
                   (SELECT string_agg(format('%I: %s', key, value), ', ')
                    FROM jsonb_each(p_properties)))
         END
     );
+    -- Dual-write to the relational edge substrate (db/44) for subgraph reasoning.
+    PERFORM upsert_memory_edge(p_from_id, p_to_id, p_relationship_type, p_properties);
 END;
 $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION auto_check_worldview_alignment()
@@ -1727,6 +1732,8 @@ BEGIN
         p_concept_name,
         p_strength
     );
+    PERFORM upsert_memory_edge('memory', p_memory_id::text, 'INSTANCE_OF', 'concept', p_concept_name,
+                               p_strength, NULL, NULL, jsonb_build_object('strength', p_strength));
     RETURN TRUE;
 EXCEPTION
     WHEN OTHERS THEN
@@ -1783,6 +1790,7 @@ BEGIN
         RETURN parent
     $q$) as (result ag_catalog.agtype)', p_child_name, p_parent_name);
 
+    PERFORM upsert_memory_edge('concept', p_parent_name, 'PARENT_OF', 'concept', p_child_name, 1.0);
     RETURN TRUE;
 EXCEPTION WHEN OTHERS THEN
     RETURN FALSE;

--- a/db/06_functions_graph_helpers.sql
+++ b/db/06_functions_graph_helpers.sql
@@ -19,6 +19,8 @@ BEGIN
         RETURN m
     $q$) as (result ag_catalog.agtype)', p_memory_id, p_episode_id, p_sequence_order);
 
+    PERFORM upsert_memory_edge('memory', p_memory_id::text, 'IN_EPISODE', 'episode', p_episode_id::text,
+                               1.0, NULL, NULL, jsonb_build_object('sequence_order', p_sequence_order));
     RETURN TRUE;
 EXCEPTION WHEN OTHERS THEN
     RETURN FALSE;

--- a/db/07_functions_heartbeat.sql
+++ b/db/07_functions_heartbeat.sql
@@ -306,6 +306,10 @@ BEGIN
             now_text,
             now_text
         );
+        PERFORM upsert_memory_edge('self', 'self', 'ASSOCIATED', 'life_chapter', 'current',
+                                   1.0, 'life_chapter_current', NULL,
+                                   jsonb_build_object('kind', 'life_chapter_current',
+                                                      'name', COALESCE(NULLIF(p_name, ''), 'Foundations')));
     EXCEPTION
         WHEN OTHERS THEN
             NULL;
@@ -348,6 +352,9 @@ BEGIN
             now_text,
             evidence_text
         );
+        PERFORM upsert_memory_edge('self', 'self', 'ASSOCIATED', 'concept', p_concept,
+                                   LEAST(1.0, GREATEST(0.0, COALESCE(p_strength, 0.8))), p_kind, NULL,
+                                   jsonb_build_object('kind', p_kind, 'evidence_memory_id', evidence_text));
     EXCEPTION
         WHEN OTHERS THEN
             NULL;

--- a/db/08_functions_goals.sql
+++ b/db/08_functions_goals.sql
@@ -133,6 +133,8 @@ BEGIN
             CREATE (root)-[:CONTAINS {priority: %L}]->(g)
             RETURN g
         $q$) as (result ag_catalog.agtype)', new_goal_id, p_priority::text);
+        PERFORM upsert_memory_edge('goals_root', 'goals', 'CONTAINS', 'goal', new_goal_id::text,
+                                   1.0, NULL, NULL, jsonb_build_object('priority', p_priority::text));
         IF p_parent_id IS NOT NULL THEN
             PERFORM link_goal_subgoal(p_parent_id, new_goal_id);
         END IF;
@@ -167,6 +169,7 @@ BEGIN
         MERGE (child)-[:SUBGOAL_OF]->(parent)
         RETURN child
     $q$) as (result ag_catalog.agtype)', p_parent_id, p_child_id);
+    PERFORM upsert_memory_edge('goal', p_child_id::text, 'SUBGOAL_OF', 'goal', p_parent_id::text, 1.0);
     RETURN TRUE;
 EXCEPTION WHEN OTHERS THEN
     RETURN FALSE;
@@ -209,6 +212,14 @@ BEGIN
             CREATE (m)-[:EVIDENCE_FOR]->(g)
             RETURN m
         $q$) as (result ag_catalog.agtype)', p_memory_id, p_goal_id);
+    END IF;
+
+    IF edge_type = 'ORIGINATED_FROM' THEN
+        PERFORM upsert_memory_edge('goal', p_goal_id::text, 'ORIGINATED_FROM', 'memory', p_memory_id::text, 1.0);
+    ELSIF edge_type = 'BLOCKS' THEN
+        PERFORM upsert_memory_edge('memory', p_memory_id::text, 'BLOCKS', 'goal', p_goal_id::text, 1.0);
+    ELSE
+        PERFORM upsert_memory_edge('memory', p_memory_id::text, 'EVIDENCE_FOR', 'goal', p_goal_id::text, 1.0);
     END IF;
 
     RETURN TRUE;
@@ -309,6 +320,9 @@ BEGIN
         RETURN from
     $q$) as (result ag_catalog.agtype)', p_from_cluster_id, p_to_cluster_id, edge_type, p_strength);
 
+    PERFORM upsert_memory_edge('cluster', p_from_cluster_id::text, edge_type,
+                               'cluster', p_to_cluster_id::text, p_strength, NULL, NULL,
+                               jsonb_build_object('strength', p_strength));
     RETURN TRUE;
 EXCEPTION WHEN OTHERS THEN
     RETURN FALSE;
@@ -359,6 +373,8 @@ BEGIN
         RETURN m
     $q$) as (result ag_catalog.agtype)', p_memory_id, p_cluster_id, p_strength, CURRENT_TIMESTAMP::text);
 
+    PERFORM upsert_memory_edge('memory', p_memory_id::text, 'MEMBER_OF', 'cluster', p_cluster_id::text,
+                               p_strength, NULL, NULL, jsonb_build_object('strength', p_strength));
     RETURN TRUE;
 EXCEPTION WHEN OTHERS THEN
     RETURN FALSE;

--- a/db/15_functions_graph_enhancements.sql
+++ b/db/15_functions_graph_enhancements.sql
@@ -51,6 +51,9 @@ BEGIN
         p_worldview_id,
         COALESCE(p_strength, 0.8)
     );
+    PERFORM upsert_memory_edge('memory', p_memory_id::text, 'SUPPORTS', 'memory', p_worldview_id::text,
+                               COALESCE(p_strength, 0.8), NULL, NULL,
+                               jsonb_build_object('strength', COALESCE(p_strength, 0.8)));
 END;
 $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION find_contradictions(p_memory_id UUID DEFAULT NULL)

--- a/db/21_functions_reconsolidation.sql
+++ b/db/21_functions_reconsolidation.sql
@@ -247,6 +247,7 @@ BEGIN
                         $q$) AS (result ag_catalog.agtype)',
                         v_memory_id, task.belief_id
                     );
+                    PERFORM delete_memory_edge('memory', v_memory_id::text, 'CONTESTED_BECAUSE', 'memory', task.belief_id::text);
                 EXCEPTION WHEN OTHERS THEN NULL;
                 END;
 
@@ -273,6 +274,9 @@ BEGIN
                         v_memory_id, task.belief_id,
                         clock_timestamp()::text, v_strength
                     );
+                    PERFORM upsert_memory_edge(v_memory_id, task.belief_id, 'CONTESTED_BECAUSE',
+                                               jsonb_build_object('strength', v_strength, 'source', 'reconsolidation',
+                                                                  'reconsolidated_at', clock_timestamp()::text));
                 EXCEPTION WHEN OTHERS THEN NULL;
                 END;
                 still_contested := still_contested + 1;
@@ -294,6 +298,7 @@ BEGIN
                         $q$) AS (result ag_catalog.agtype)',
                         v_memory_id, task.belief_id
                     );
+                    PERFORM delete_memory_edge('memory', v_memory_id::text, 'SUPPORTS', 'memory', task.belief_id::text);
                 EXCEPTION WHEN OTHERS THEN NULL;
                 END;
 
@@ -316,6 +321,9 @@ BEGIN
                         v_memory_id, task.belief_id,
                         clock_timestamp()::text, v_strength
                     );
+                    PERFORM upsert_memory_edge(v_memory_id, task.belief_id, 'SUPPORTS',
+                                               jsonb_build_object('strength', v_strength, 'source', 'reconsolidation',
+                                                                  'reconsolidated_at', clock_timestamp()::text));
                 EXCEPTION WHEN OTHERS THEN NULL;
                 END;
                 kept := kept + 1;

--- a/db/39_functions_prompt_render.sql
+++ b/db/39_functions_prompt_render.sql
@@ -30,6 +30,30 @@ RETURNS jsonb LANGUAGE sql IMMUTABLE AS $$
     SELECT CASE WHEN v IS NOT NULL AND jsonb_typeof(v) = 'array' THEN v ELSE '[]'::jsonb END;
 $$;
 
+-- Render a dynamic sub-knowledge-graph (build_context_subgraph output:
+-- {nodes, edges}) as compact markdown: each typed edge as "A  —rel→  B" using
+-- node labels, grouped by relation. Returns NULL when there is no structure to
+-- show, so callers can omit the section entirely.
+CREATE OR REPLACE FUNCTION render_subgraph(p jsonb)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+    WITH nodes AS (
+        SELECT (n->>'type') AS ntype, (n->>'id') AS nid,
+               left(COALESCE(NULLIF(btrim(n->>'label'), ''), n->>'id'), 80) AS label
+        FROM jsonb_array_elements(_pr_arr(p->'nodes')) n
+    ),
+    edges AS (
+        SELECT (e->>'src_type') AS st, (e->>'src_id') AS si, (e->>'rel') AS rel,
+               (e->>'dst_type') AS dt, (e->>'dst_id') AS di
+        FROM jsonb_array_elements(_pr_arr(p->'edges')) e
+    )
+    SELECT string_agg(
+        '  - ' || COALESCE(ns.label, e.si) || '  —' || lower(e.rel) || '→  ' || COALESCE(nd.label, e.di),
+        E'\n' ORDER BY e.rel, ns.label, nd.label)
+    FROM edges e
+    LEFT JOIN nodes ns ON ns.ntype = e.st AND ns.nid = e.si
+    LEFT JOIN nodes nd ON nd.ntype = e.dt AND nd.nid = e.di;
+$$;
+
 -- --- list formatters --------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION render_goals(p_goals jsonb)

--- a/db/44_functions_memory_edges.sql
+++ b/db/44_functions_memory_edges.sql
@@ -1,0 +1,268 @@
+-- Relational typed-edge substrate for dynamic sub-knowledge-graph reasoning.
+--
+-- Mirrors the Apache AGE `memory_graph` edges into a plain relational table so
+-- multi-hop, seeded subgraph assembly runs as a Postgres WITH RECURSIVE over
+-- btree indexes (no agtype) and joins directly to `memories` for scoring. AGE
+-- stays authoritative/written for ad-hoc Cypher; memory_edges is the primary
+-- substrate for the reasoning path (build_context_subgraph, db/44 Phase 2).
+--
+-- Node addressing is generic (node_type, node_key) so heterogeneous endpoints
+-- fit one table:
+--   memory/goal   -> memories.id::text
+--   cluster       -> clusters.id::text
+--   episode       -> episodes.id::text
+--   concept       -> concept name
+--   self/goals_root/life_chapter -> singleton key ('self'/'goals'/'current')
+SET search_path = public, ag_catalog, "$user";
+
+CREATE TABLE IF NOT EXISTS memory_edges (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    src_type   TEXT NOT NULL,
+    src_id     TEXT NOT NULL,
+    -- TEXT, not the graph_edge_type enum: the graph's edge vocabulary is
+    -- open-ended (MEMBER_OF/CONTAINS/HAS_BELIEF are real labels the enum omits).
+    -- The enum stays as create_memory_relationship's typed contract only.
+    rel_type   TEXT NOT NULL,
+    dst_type   TEXT NOT NULL,
+    dst_id     TEXT NOT NULL,
+    weight     FLOAT NOT NULL DEFAULT 1.0,
+    kind       TEXT,
+    source     TEXT,
+    properties JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (src_type, src_id, rel_type, dst_type, dst_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_edges_src ON memory_edges (src_type, src_id, rel_type);
+CREATE INDEX IF NOT EXISTS idx_memory_edges_dst ON memory_edges (dst_type, dst_id, rel_type);
+
+-- Dual-write hook: called beside each AGE edge write. Upsert on the natural key.
+CREATE OR REPLACE FUNCTION upsert_memory_edge(
+    p_src_type TEXT,
+    p_src_id   TEXT,
+    p_rel_type TEXT,
+    p_dst_type TEXT,
+    p_dst_id   TEXT,
+    p_weight   FLOAT DEFAULT 1.0,
+    p_kind     TEXT DEFAULT NULL,
+    p_source   TEXT DEFAULT NULL,
+    p_properties JSONB DEFAULT '{}'::jsonb
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NULLIF(btrim(COALESCE(p_src_id, '')), '') IS NULL
+       OR NULLIF(btrim(COALESCE(p_dst_id, '')), '') IS NULL THEN
+        RETURN;  -- never store a dangling edge
+    END IF;
+    INSERT INTO memory_edges (src_type, src_id, rel_type, dst_type, dst_id, weight, kind, source, properties)
+    VALUES (
+        p_src_type, p_src_id, p_rel_type, p_dst_type, p_dst_id,
+        COALESCE(p_weight, 1.0), p_kind, p_source, COALESCE(p_properties, '{}'::jsonb)
+    )
+    ON CONFLICT (src_type, src_id, rel_type, dst_type, dst_id) DO UPDATE SET
+        weight     = COALESCE(EXCLUDED.weight, memory_edges.weight),
+        kind       = COALESCE(EXCLUDED.kind, memory_edges.kind),
+        source     = COALESCE(EXCLUDED.source, memory_edges.source),
+        properties = memory_edges.properties || EXCLUDED.properties,
+        updated_at = CURRENT_TIMESTAMP;
+END;
+$$;
+
+-- Convenience overload for the common memory->memory case (UUID endpoints),
+-- pulling weight from strength/confidence in the properties (matches the AGE
+-- create_memory_relationship contract).
+CREATE OR REPLACE FUNCTION upsert_memory_edge(
+    p_from_id UUID,
+    p_to_id   UUID,
+    p_rel_type graph_edge_type,
+    p_properties JSONB DEFAULT '{}'::jsonb
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM upsert_memory_edge(
+        'memory', p_from_id::text, p_rel_type::text, 'memory', p_to_id::text,
+        COALESCE((p_properties->>'strength')::float, (p_properties->>'confidence')::float, 1.0),
+        p_properties->>'kind',
+        p_properties->>'source',
+        COALESCE(p_properties, '{}'::jsonb)
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION delete_memory_edge(
+    p_src_type TEXT, p_src_id TEXT, p_rel_type TEXT, p_dst_type TEXT, p_dst_id TEXT
+) RETURNS VOID
+LANGUAGE sql
+AS $$
+    DELETE FROM memory_edges
+    WHERE src_type = p_src_type AND src_id = p_src_id AND rel_type = p_rel_type
+      AND dst_type = p_dst_type AND dst_id = p_dst_id;
+$$;
+
+-- Map an AGE node label + its property map to (node_type, node_key).
+CREATE OR REPLACE FUNCTION _memory_edge_node_ref(p_label TEXT, p_props JSONB)
+RETURNS TEXT[]   -- [node_type, node_key]
+LANGUAGE sql IMMUTABLE
+AS $$
+    SELECT CASE p_label
+        WHEN 'MemoryNode'      THEN ARRAY['memory',       p_props->>'memory_id']
+        WHEN 'GoalNode'        THEN ARRAY['goal',         p_props->>'goal_id']
+        WHEN 'ConceptNode'     THEN ARRAY['concept',      p_props->>'name']
+        WHEN 'ClusterNode'     THEN ARRAY['cluster',      p_props->>'cluster_id']
+        WHEN 'EpisodeNode'     THEN ARRAY['episode',      p_props->>'episode_id']
+        WHEN 'SelfNode'        THEN ARRAY['self',         COALESCE(p_props->>'key', 'self')]
+        WHEN 'GoalsRoot'       THEN ARRAY['goals_root',   COALESCE(p_props->>'key', 'goals')]
+        WHEN 'LifeChapterNode' THEN ARRAY['life_chapter', COALESCE(p_props->>'key', 'current')]
+        ELSE ARRAY[lower(p_label), COALESCE(p_props->>'memory_id', p_props->>'name', p_props->>'key')]
+    END;
+$$;
+
+-- One-time migration: populate memory_edges from the live AGE graph. Iterates
+-- every edge (all labels at once), resolving endpoint types/keys from node
+-- labels. Idempotent (upsert). Returns the number of edges backfilled.
+CREATE OR REPLACE FUNCTION backfill_memory_edges()
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    rec RECORD;
+    n INTEGER := 0;
+    src_ref TEXT[];
+    dst_ref TEXT[];
+    props JSONB;
+    rt TEXT;
+BEGIN
+    FOR rec IN
+        SELECT * FROM ag_catalog.cypher('memory_graph', $q$
+            MATCH (a)-[r]->(b)
+            RETURN label(a), properties(a), type(r), properties(r), label(b), properties(b)
+        $q$) AS (la agtype, pa agtype, rt agtype, pr agtype, lb agtype, pb agtype)
+    LOOP
+        rt := btrim(rec.rt::text, '"');
+        src_ref := _memory_edge_node_ref(btrim(rec.la::text, '"'), (rec.pa::text)::jsonb);
+        dst_ref := _memory_edge_node_ref(btrim(rec.lb::text, '"'), (rec.pb::text)::jsonb);
+        props   := COALESCE((rec.pr::text)::jsonb, '{}'::jsonb);
+        PERFORM upsert_memory_edge(
+            src_ref[1], src_ref[2], rt, dst_ref[1], dst_ref[2],
+            COALESCE((props->>'strength')::float, (props->>'confidence')::float, 1.0),
+            props->>'kind', props->>'source', props
+        );
+        n := n + 1;
+    END LOOP;
+    RETURN n;
+END;
+$$;
+
+-- Cast text->uuid, returning NULL instead of erroring on non-uuid keys (concept
+-- names, singleton keys). Lets node-label joins run over heterogeneous node ids.
+CREATE OR REPLACE FUNCTION _safe_uuid(p TEXT)
+RETURNS UUID
+LANGUAGE plpgsql IMMUTABLE
+AS $$
+BEGIN
+    RETURN p::uuid;
+EXCEPTION WHEN OTHERS THEN
+    RETURN NULL;
+END;
+$$;
+
+-- Dynamic sub-knowledge-graph: given seed memories, expand outward over
+-- memory_edges (both directions, bounded depth, weighted, budgeted) and return
+-- a focused subgraph as JSONB {nodes, edges}. This is the primary graph-
+-- reasoning path -- it reveals the *structure* (supports/contradicts/causes/...)
+-- among + around what recall surfaced, which flat vector recall cannot.
+--   p_rel_types: restrict expansion to these edge types (NULL = all).
+--   p_depth:     max hops from a seed (clamped 0..6).
+--   p_budget:    max nodes in the result (clamped 1..500); seeds are kept first.
+CREATE OR REPLACE FUNCTION build_context_subgraph(
+    p_seed_ids UUID[],
+    p_depth INT DEFAULT 2,
+    p_rel_types TEXT[] DEFAULT NULL,
+    p_budget INT DEFAULT 40
+) RETURNS JSONB
+LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+    result JSONB;
+    v_depth  INT := LEAST(GREATEST(COALESCE(p_depth, 2), 0), 6);
+    v_budget INT := LEAST(GREATEST(COALESCE(p_budget, 40), 1), 500);
+BEGIN
+    IF p_seed_ids IS NULL OR array_length(p_seed_ids, 1) IS NULL THEN
+        RETURN jsonb_build_object('nodes', '[]'::jsonb, 'edges', '[]'::jsonb);
+    END IF;
+
+    WITH RECURSIVE
+    -- Undirected edge view (each edge usable from either endpoint), rel-filtered.
+    adj AS (
+        SELECT src_type AS from_type, src_id AS from_id,
+               dst_type AS to_type,   dst_id AS to_id, weight, rel_type
+        FROM memory_edges
+        WHERE p_rel_types IS NULL OR rel_type::text = ANY(p_rel_types)
+        UNION ALL
+        SELECT dst_type, dst_id, src_type, src_id, weight, rel_type
+        FROM memory_edges
+        WHERE p_rel_types IS NULL OR rel_type::text = ANY(p_rel_types)
+    ),
+    frontier AS (
+        SELECT 'memory'::text AS node_type, s::text AS node_id, 0 AS depth,
+               1.0::float AS path_weight, ARRAY['memory:' || s::text] AS visited
+        FROM unnest(p_seed_ids) s
+        UNION ALL
+        SELECT a.to_type, a.to_id, f.depth + 1, f.path_weight * COALESCE(a.weight, 1.0),
+               f.visited || (a.to_type || ':' || a.to_id)
+        FROM frontier f
+        JOIN adj a ON a.from_type = f.node_type AND a.from_id = f.node_id
+        WHERE f.depth < v_depth
+          AND NOT ((a.to_type || ':' || a.to_id) = ANY(f.visited))  -- cycle guard
+    ),
+    reached AS (
+        SELECT node_type, node_id, MIN(depth) AS depth, MAX(path_weight) AS relevance
+        FROM frontier
+        GROUP BY node_type, node_id
+    ),
+    kept AS (
+        SELECT node_type, node_id, depth, relevance
+        FROM reached
+        ORDER BY depth ASC, relevance DESC, node_id
+        LIMIT v_budget
+    ),
+    node_json AS (
+        SELECT jsonb_agg(jsonb_build_object(
+            'type', k.node_type,
+            'id',   k.node_id,
+            'label', left(COALESCE(m.content, cl.name, ep.summary, k.node_id), 200),
+            'memory_type', m.type,
+            'importance', m.importance,
+            'depth', k.depth,
+            'relevance', round(k.relevance::numeric, 4)
+        ) ORDER BY k.depth, k.relevance DESC) AS arr
+        FROM kept k
+        LEFT JOIN memories m ON k.node_type IN ('memory', 'goal') AND m.id = _safe_uuid(k.node_id)
+        LEFT JOIN clusters cl ON k.node_type = 'cluster'  AND cl.id = _safe_uuid(k.node_id)
+        LEFT JOIN episodes ep ON k.node_type = 'episode'  AND ep.id = _safe_uuid(k.node_id)
+    ),
+    edge_json AS (
+        SELECT jsonb_agg(DISTINCT jsonb_build_object(
+            'src_type', e.src_type, 'src_id', e.src_id,
+            'rel', e.rel_type::text,
+            'dst_type', e.dst_type, 'dst_id', e.dst_id,
+            'weight', round(e.weight::numeric, 4)
+        )) AS arr
+        FROM memory_edges e
+        WHERE (e.src_type, e.src_id) IN (SELECT node_type, node_id FROM kept)
+          AND (e.dst_type, e.dst_id) IN (SELECT node_type, node_id FROM kept)
+          AND (p_rel_types IS NULL OR e.rel_type::text = ANY(p_rel_types))
+    )
+    SELECT jsonb_build_object(
+        'nodes', COALESCE(node_json.arr, '[]'::jsonb),
+        'edges', COALESCE(edge_json.arr, '[]'::jsonb)
+    )
+    INTO result
+    FROM node_json, edge_json;
+
+    RETURN COALESCE(result, jsonb_build_object('nodes', '[]'::jsonb, 'edges', '[]'::jsonb));
+END;
+$$;

--- a/tests/db/test_memory_edges.py
+++ b/tests/db/test_memory_edges.py
@@ -1,0 +1,164 @@
+"""Tests for the relational sub-knowledge-graph substrate (db/44_functions_memory_edges.sql).
+
+Covers upsert_memory_edge (dual-write hook), build_context_subgraph (seeded,
+bounded, weighted subgraph assembly), and render_subgraph. Uses synthetic edges
+inserted directly via upsert_memory_edge, so no embedding service or AGE graph
+is required -- the assembly is pure relational recursion.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = [pytest.mark.asyncio(loop_scope="session")]
+
+# Synthetic node ids (never inserted into `memories`, so no triggers fire and the
+# graph is fully deterministic; labels fall back to the node id).
+A = "0aaaaaaa-0000-0000-0000-000000000001"
+B = "0aaaaaaa-0000-0000-0000-000000000002"
+C = "0aaaaaaa-0000-0000-0000-000000000003"
+CLUSTER = "0ccccccc-0000-0000-0000-000000000001"
+CONCEPT = "topic_x"
+
+
+def _j(v):
+    return json.loads(v) if isinstance(v, str) else v
+
+
+async def _seed(conn):
+    """A --causes--> B --causes--> C ; A --instance_of--> concept ; A --member_of--> cluster."""
+    async def edge(st, si, rel, dt, di, w=1.0):
+        await conn.execute(
+            "SELECT upsert_memory_edge($1::text,$2::text,$3::text,$4::text,$5::text,$6::float,"
+            "NULL::text,NULL::text,'{}'::jsonb)",
+            st, si, rel, dt, di, w,
+        )
+    await edge("memory", A, "CAUSES", "memory", B, 0.8)
+    await edge("memory", B, "CAUSES", "memory", C, 0.9)
+    await edge("memory", A, "INSTANCE_OF", "concept", CONCEPT, 0.7)
+    await edge("memory", A, "MEMBER_OF", "cluster", CLUSTER, 0.6)
+
+
+async def _subgraph(conn, seeds, depth, rel_types, budget):
+    return _j(await conn.fetchval(
+        "SELECT build_context_subgraph($1::uuid[], $2, $3::text[], $4)",
+        seeds, depth, rel_types, budget,
+    ))
+
+
+def _ids(sg):
+    return {n["id"] for n in sg["nodes"]}
+
+
+def _typed(sg):
+    return {(n["type"], n["id"]) for n in sg["nodes"]}
+
+
+async def test_dual_write_upsert_is_idempotent(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            await conn.execute(
+                "SELECT upsert_memory_edge('memory',$1,'CAUSES','memory',$2,0.5,NULL,NULL,'{}'::jsonb)", A, B)
+            await conn.execute(
+                "SELECT upsert_memory_edge('memory',$1,'CAUSES','memory',$2,0.9,NULL,NULL,'{}'::jsonb)", A, B)
+            # Same natural key -> one row, weight updated to the latest.
+            n = await conn.fetchval(
+                "SELECT count(*) FROM memory_edges WHERE src_id=$1 AND dst_id=$2 AND rel_type='CAUSES'", A, B)
+            w = await conn.fetchval(
+                "SELECT weight FROM memory_edges WHERE src_id=$1 AND dst_id=$2 AND rel_type='CAUSES'", A, B)
+            assert n == 1
+            assert abs(w - 0.9) < 1e-9
+        finally:
+            await tr.rollback()
+
+
+async def test_full_subgraph_reaches_causal_chain_and_bridges(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            await _seed(conn)
+            sg = await _subgraph(conn, [A], 3, None, 40)
+            # A (seed) + B + C (2-hop causal) + concept + cluster.
+            assert _ids(sg) == {A, B, C, CONCEPT, CLUSTER}
+            # heterogeneous-node resolution: correct node types.
+            assert ("concept", CONCEPT) in _typed(sg)
+            assert ("cluster", CLUSTER) in _typed(sg)
+            assert ("memory", C) in _typed(sg)
+            # every edge connects two kept nodes (no dangling edges).
+            kept = _ids(sg)
+            for e in sg["edges"]:
+                assert e["src_id"] in kept and e["dst_id"] in kept
+        finally:
+            await tr.rollback()
+
+
+async def test_depth_bound(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            await _seed(conn)
+            sg = await _subgraph(conn, [A], 1, None, 40)
+            # depth 1 from A reaches direct neighbours only: B, concept, cluster -- not C.
+            assert _ids(sg) == {A, B, CONCEPT, CLUSTER}
+            assert C not in _ids(sg)
+        finally:
+            await tr.rollback()
+
+
+async def test_rel_type_filter(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            await _seed(conn)
+            sg = await _subgraph(conn, [A], 3, ["CAUSES"], 40)
+            # CAUSES-only expansion: the causal chain, no concept/cluster bridges.
+            assert _ids(sg) == {A, B, C}
+            assert all(e["rel"] == "CAUSES" for e in sg["edges"])
+        finally:
+            await tr.rollback()
+
+
+async def test_budget_cap_keeps_seed(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            await _seed(conn)
+            sg = await _subgraph(conn, [A], 3, None, 1)
+            # budget 1 -> only the seed (seeds sort first, depth 0).
+            assert _ids(sg) == {A}
+        finally:
+            await tr.rollback()
+
+
+async def test_empty_seed_returns_empty(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            sg = await _subgraph(conn, [], 3, None, 40)
+            assert sg["nodes"] == [] and sg["edges"] == []
+        finally:
+            await tr.rollback()
+
+
+async def test_render_subgraph_shows_typed_edges(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            await _seed(conn)
+            rendered = await conn.fetchval(
+                "SELECT render_subgraph(build_context_subgraph($1::uuid[], 3, ARRAY['CAUSES'], 40))", [A])
+            # One line per causal edge, using node ids as labels (no memories rows).
+            assert rendered is not None
+            assert "causes" in rendered
+            assert rendered.count("—causes→") == 2
+        finally:
+            await tr.rollback()


### PR DESCRIPTION
## Dynamic sub-knowledge-graph as the primary reasoning path (Phases 1–3)

Hexis wrote a rich typed knowledge graph on **every memory insert** (13 node types, ~18 edge types) but only *read* it through flat, un-seeded point queries. So recall was flat: the agent saw "memories that resemble your query," never the **structure** — that memory A *supports* belief B which *contradicts* C, that these episodes *caused* this pattern.

This makes the graph load-bearing for reasoning, on a **relational edge substrate** (Postgres `WITH RECURSIVE`, no agtype), while **keeping AGE dual-written** for ad-hoc Cypher.

### Phase 1 — substrate + dual-write (`db/44`, + hooks in db/05,06,07,08,15,21)
- `memory_edges` with generic `(node_type, node_key)` addressing so heterogeneous endpoints (memory/goal/concept/cluster/episode/self) fit one table. `rel_type` is **TEXT** — the graph's edge vocabulary is open-ended (`MEMBER_OF`/`CONTAINS`/`HAS_BELIEF` aren't in the enum).
- `upsert_memory_edge` / `delete_memory_edge` / `backfill_memory_edges()`.
- Dual-write hooked beside every low-level AGE edge writer + reconsolidation mutate/delete. Verified: writes fire automatically (incl. via the episode trigger) with **exact AGE parity**.

### Phase 2 — assembly + rendering (`db/44`, `db/39`)
- `build_context_subgraph(seeds, depth, rel_types, budget)` — recursive, both-directions, cycle-guarded, weighted, budget-capped (no supernode blowups); returns `{nodes, edges}` JSONB, joins `memories`/`clusters`/`episodes` for labels.
- `render_subgraph` → `A  —rel→  B` lines.
- `tests/db/test_memory_edges.py` (7): shape, depth/budget/rel bounds, heterogeneous-node resolution, idempotent upsert, render.

### Phase 3 — primary chat path (`core/cognitive_memory_api.py`)
- `HydratedContext.subgraph`; `hydrate()` seeds the subgraph from the recalled memories (curated to `REASONING_EDGE_TYPES` so episode/cluster hubs don't over-connect); `format_context_for_prompt` renders a `## Knowledge Subgraph` block.

Real hydrate output:
```
## Knowledge Subgraph
- lighthouse … solar power  —causes→  keeper logs the tides
- keeper logs the tides  —causes→  tidal logs … monthly rhythm
- lighthouse … solar power  —supports→  Renewable power is worth the effort
```

### Verification
- Clean `down -v && build db && up` applies from scratch; dual-write parity; `tests/db/test_memory_edges.py` (7) + 50 graph regressions + 19 core-API tests all green.
- Additive: nothing removed, AGE still dual-written. Follow-up (Phase 4): `explore_subgraph` tool + heartbeat wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
