### PR TITLE
explore_subgraph tool + heartbeat wiring (Phase 4, additive)

### DIFF
--- a/core/tools/memory.py
+++ b/core/tools/memory.py
@@ -504,6 +504,109 @@ class ExploreConceptHandler(ToolHandler):
             return ToolResult.error_result(str(e), ToolErrorType.EXECUTION_FAILED)
 
 
+class ExploreSubgraphHandler(ToolHandler):
+    """Assemble a dynamic sub-knowledge-graph around seed memories."""
+
+    @property
+    def spec(self) -> ToolSpec:
+        return ToolSpec(
+            name="explore_subgraph",
+            description=(
+                "Assemble a focused sub-knowledge-graph around memories: expand over typed "
+                "relationships (causes, supports, contradicts, derived_from, instance_of, ...) "
+                "to see how they connect -- the belief/causal structure, not a flat list. "
+                "Seed with a query (recalls memories) or explicit memory ids. Use this when a "
+                "question is about how things relate, contradict, or lead to one another."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Recall seed memories matching this text (used if 'seeds' omitted).",
+                    },
+                    "seeds": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Explicit seed memory ids (uuid). Use if you already have them.",
+                    },
+                    "rel_types": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Restrict expansion to these edge types (e.g. ['CAUSES','SUPPORTS']). Omit for all.",
+                    },
+                    "depth": {
+                        "type": "integer",
+                        "description": "Max hops from a seed.",
+                        "default": 2,
+                        "minimum": 1,
+                        "maximum": 4,
+                    },
+                    "budget": {
+                        "type": "integer",
+                        "description": "Max nodes in the result.",
+                        "default": 30,
+                        "minimum": 1,
+                        "maximum": 100,
+                    },
+                },
+            },
+            category=ToolCategory.MEMORY,
+            energy_cost=1,
+            is_read_only=True,
+        )
+
+    async def execute(
+        self,
+        arguments: dict[str, Any],
+        context: ToolExecutionContext,
+    ) -> ToolResult:
+        seeds = arguments.get("seeds")
+        query = arguments.get("query")
+        rel_types = arguments.get("rel_types")
+        depth = arguments.get("depth", 2)
+        budget = arguments.get("budget", 30)
+
+        try:
+            async with context.registry.pool.acquire() as conn:
+                if seeds:
+                    seed_ids = [str(s) for s in seeds]
+                elif query:
+                    rows = await conn.fetch("SELECT memory_id FROM fast_recall($1, 10)", query)
+                    seed_ids = [str(r["memory_id"]) for r in rows]
+                else:
+                    return ToolResult.error_result(
+                        "Provide 'query' or 'seeds'.", ToolErrorType.INVALID_PARAMS
+                    )
+
+                if not seed_ids:
+                    return ToolResult.success_result(
+                        output={"nodes": [], "edges": [], "rendered": None},
+                        display_output="No seed memories found.",
+                    )
+
+                sg = await conn.fetchval(
+                    "SELECT build_context_subgraph($1::uuid[], $2, $3::text[], $4)",
+                    seed_ids, depth, rel_types, budget,
+                )
+                rendered = await conn.fetchval("SELECT render_subgraph($1::jsonb)", sg)
+
+            sg_obj = json.loads(sg) if isinstance(sg, str) else (sg or {})
+            nodes = sg_obj.get("nodes", [])
+            edges = sg_obj.get("edges", [])
+            return ToolResult.success_result(
+                output={"nodes": nodes, "edges": edges, "rendered": rendered},
+                display_output=(
+                    rendered
+                    if rendered
+                    else f"No typed connections among {len(seed_ids)} seed memory(ies)."
+                ),
+            )
+
+        except Exception as e:
+            return ToolResult.error_result(str(e), ToolErrorType.EXECUTION_FAILED)
+
+
 class GetProceduresHandler(ToolHandler):
     """Retrieve procedural memories for a task."""
 
@@ -1052,6 +1155,7 @@ def create_memory_tools() -> list[ToolHandler]:
         RememberHandler(),
         SenseMemoryAvailabilityHandler(),
         ExploreConceptHandler(),
+        ExploreSubgraphHandler(),
         GetProceduresHandler(),
         GetStrategiesHandler(),
         QueueUserMessageHandler(),

--- a/db/13_functions_emotional_state.sql
+++ b/db/13_functions_emotional_state.sql
@@ -719,6 +719,7 @@ DECLARE
     action_costs JSONB;
     contradictions JSONB;
     allowed_actions JSONB;
+    v_seed_ids UUID[];
 BEGIN
     SELECT * INTO state_record FROM heartbeat_state WHERE id = 1;
     allowed_actions := get_config('heartbeat.allowed_actions');
@@ -744,11 +745,24 @@ BEGIN
 
     contradictions := get_contradictions_context(5);
 
+    -- Seed the dynamic sub-knowledge-graph from the most recently active memories
+    -- so the heartbeat reasons over their belief/causal structure, not a flat list.
+    SELECT array_agg(id) INTO v_seed_ids FROM (
+        SELECT id FROM memories
+        WHERE status = 'active'
+        ORDER BY COALESCE(last_accessed, created_at) DESC
+        LIMIT 8
+    ) s;
+
     RETURN jsonb_build_object(
         'agent', get_agent_profile_context(),
         'environment', get_environment_snapshot(),
         'goals', get_goals_snapshot(),
         'recent_memories', get_recent_context(5),
+        'subgraph', build_context_subgraph(
+            v_seed_ids, 2,
+            ARRAY['CAUSES','SUPPORTS','CONTRADICTS','DERIVED_FROM','CONTESTED_BECAUSE',
+                  'INSTANCE_OF','ASSOCIATED','TEMPORAL_NEXT'], 30),
         'identity', get_identity_context(),
         'worldview', get_worldview_context(),
         'self_model', get_self_model_context(25),

--- a/db/39_functions_prompt_render.sql
+++ b/db/39_functions_prompt_render.sql
@@ -715,6 +715,11 @@ BEGIN
         -- Python defaults absent keys: narrative/backlog -> {}, allowed_actions -> []
         || '## Narrative' || E'\n' || render_narrative(CASE WHEN ctx ? 'narrative' THEN ctx->'narrative' ELSE '{}'::jsonb END) || E'\n\n'
         || '## Recent Experience' || E'\n' || render_memories(ctx->'recent_memories') || E'\n\n'
+        || CASE WHEN render_subgraph(ctx->'subgraph') IS NOT NULL
+                THEN '## Knowledge Subgraph' || E'\n'
+                     || 'How your recent memories connect (typed links among + around them):' || E'\n'
+                     || render_subgraph(ctx->'subgraph') || E'\n\n'
+                ELSE '' END
         || '## Your Identity' || E'\n' || render_identity(ctx->'identity') || E'\n\n'
         || '## Your Self-Model' || E'\n' || render_self_model(ctx->'self_model') || E'\n\n'
         || '## Relationships' || E'\n' || render_relationships(ctx->'relationships') || E'\n\n'


### PR DESCRIPTION
## explore_subgraph tool + heartbeat wiring (Phase 4, additive)

Builds on #26 (the sub-knowledge-graph substrate + primary chat path). Makes the subgraph reachable from the **heartbeat** and as an **agent tool**, so reasoning-over-structure isn't chat-only. Purely additive — the AGE reader functions are untouched (subsumption deferred by choice).

### `explore_subgraph` tool (`core/tools/memory.py`)
On-demand sub-knowledge-graph assembly. Seed by `query` (recalls memories via `fast_recall`) or explicit `seeds` (memory ids); filter `rel_types`; bounded `depth`/`budget`. Returns the typed `{nodes, edges}` + a rendered display via `build_context_subgraph`/`render_subgraph`. Read-only, energy 1, registered in `create_memory_tools()`. Use it when a question is about how things relate/contradict/lead to one another.

### Heartbeat wiring (`db/13`, `db/39`)
- `gather_turn_context()` now includes a `subgraph` key, seeded from the 8 most recently-active memories, curated to reasoning edges (causes/supports/contradicts/derived_from/contested_because/instance_of/associated/temporal_next).
- `render_heartbeat_decision_prompt()` renders a `## Knowledge Subgraph` block after Recent Experience — guarded so an empty subgraph (NULL from `render_subgraph`) doesn't null the whole prompt.

Heartbeat prompt now shows e.g. `coolant pump failed —causes→ reactor overheated`.

### Verification
- Clean `down -v && build db && up` applies from scratch (ordering ok); tool registers + executes end-to-end; heartbeat prompt shows the block.
- `tests/db/test_memory_edges.py` + `test_prompt_render.py` + `test_core_api.py` + `test_tool_unification.py` (73) and `test_heartbeat_task_mode.py` (34) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new memory exploration tool that can build and return a connected subgraph from a search query or selected memory seeds.
  * Added subgraph context to heartbeat-related memory lookups, using recent memories to surface related connections.
  * Updated prompt output to show a readable “Knowledge Subgraph” section when available, making memory relationships easier to inspect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->