### PR TITLE
Reflect live memories in the subgraph (consistency under maintenance)

### DIFF
--- a/db/17_functions_subconscious_observations.sql
+++ b/db/17_functions_subconscious_observations.sql
@@ -1114,6 +1114,10 @@ BEGIN
                         contra_a,
                         contra_b
                     );
+                    -- Mirror the resolved-contradiction deletion to memory_edges
+                    -- (undirected, so clear both stored directions).
+                    PERFORM delete_memory_edge('memory', contra_a::text, 'CONTRADICTS', 'memory', contra_b::text);
+                    PERFORM delete_memory_edge('memory', contra_b::text, 'CONTRADICTS', 'memory', contra_a::text);
                 END IF;
             EXCEPTION WHEN OTHERS THEN NULL;
             END;

--- a/db/44_functions_memory_edges.sql
+++ b/db/44_functions_memory_edges.sql
@@ -195,21 +195,39 @@ BEGIN
     END IF;
 
     WITH RECURSIVE
-    -- Undirected edge view (each edge usable from either endpoint), rel-filtered.
+    -- Live memories only. memory_edges is a DERIVED edge store, not the source of
+    -- truth: `memories` is. As maintenance consolidates/prunes/invalidates
+    -- memories (soft state changes), those memories -- and every edge touching
+    -- them -- drop out here, so the subgraph always reflects the current memory
+    -- set without needing to delete edge rows.
+    live_mem AS (
+        SELECT id FROM memories
+        WHERE status = 'active' AND (valid_until IS NULL OR valid_until > CURRENT_TIMESTAMP)
+    ),
+    -- Edges whose memory/goal endpoints are live (concept/cluster/episode/self
+    -- endpoints carry no memory status and pass through). rel-filtered here so
+    -- both traversal and output see the same live edge set.
+    edges_live AS (
+        SELECT e.src_type, e.src_id, e.dst_type, e.dst_id, e.weight, e.rel_type
+        FROM memory_edges e
+        WHERE (p_rel_types IS NULL OR e.rel_type = ANY(p_rel_types))
+          AND (e.src_type NOT IN ('memory', 'goal') OR _safe_uuid(e.src_id) IN (SELECT id FROM live_mem))
+          AND (e.dst_type NOT IN ('memory', 'goal') OR _safe_uuid(e.dst_id) IN (SELECT id FROM live_mem))
+    ),
+    -- Undirected view (each live edge usable from either endpoint).
     adj AS (
         SELECT src_type AS from_type, src_id AS from_id,
                dst_type AS to_type,   dst_id AS to_id, weight, rel_type
-        FROM memory_edges
-        WHERE p_rel_types IS NULL OR rel_type::text = ANY(p_rel_types)
+        FROM edges_live
         UNION ALL
         SELECT dst_type, dst_id, src_type, src_id, weight, rel_type
-        FROM memory_edges
-        WHERE p_rel_types IS NULL OR rel_type::text = ANY(p_rel_types)
+        FROM edges_live
     ),
     frontier AS (
         SELECT 'memory'::text AS node_type, s::text AS node_id, 0 AS depth,
                1.0::float AS path_weight, ARRAY['memory:' || s::text] AS visited
         FROM unnest(p_seed_ids) s
+        WHERE s IN (SELECT id FROM live_mem)   -- only live seeds enter
         UNION ALL
         SELECT a.to_type, a.to_id, f.depth + 1, f.path_weight * COALESCE(a.weight, 1.0),
                f.visited || (a.to_type || ':' || a.to_id)
@@ -251,10 +269,9 @@ BEGIN
             'dst_type', e.dst_type, 'dst_id', e.dst_id,
             'weight', round(e.weight::numeric, 4)
         )) AS arr
-        FROM memory_edges e
+        FROM edges_live e
         WHERE (e.src_type, e.src_id) IN (SELECT node_type, node_id FROM kept)
           AND (e.dst_type, e.dst_id) IN (SELECT node_type, node_id FROM kept)
-          AND (p_rel_types IS NULL OR e.rel_type::text = ANY(p_rel_types))
     )
     SELECT jsonb_build_object(
         'nodes', COALESCE(node_json.arr, '[]'::jsonb),

--- a/tests/db/test_memory_edges.py
+++ b/tests/db/test_memory_edges.py
@@ -27,7 +27,17 @@ def _j(v):
 
 
 async def _seed(conn):
-    """A --causes--> B --causes--> C ; A --instance_of--> concept ; A --member_of--> cluster."""
+    """A --causes--> B --causes--> C ; A --instance_of--> concept ; A --member_of--> cluster.
+    A/B/C are inserted as live memories -- build_context_subgraph filters memory
+    endpoints to live rows, so synthetic (non-existent) memory nodes are excluded."""
+    for mid, content in ((A, "A"), (B, "B"), (C, "C")):
+        await conn.execute(
+            "INSERT INTO memories (id, type, content, embedding, importance, trust_level, status) "
+            "VALUES ($1::uuid, 'episodic', $2, array_fill(0.1, ARRAY[embedding_dimension()])::vector, "
+            "0.7, 0.9, 'active')",
+            mid, content,
+        )
+
     async def edge(st, si, rel, dt, di, w=1.0):
         await conn.execute(
             "SELECT upsert_memory_edge($1::text,$2::text,$3::text,$4::text,$5::text,$6::float,"
@@ -81,7 +91,8 @@ async def test_full_subgraph_reaches_causal_chain_and_bridges(db_pool):
         await tr.start()
         try:
             await _seed(conn)
-            sg = await _subgraph(conn, [A], 3, None, 40)
+            # Filter to the seeded rel types (memory inserts may add IN_EPISODE).
+            sg = await _subgraph(conn, [A], 3, ["CAUSES", "INSTANCE_OF", "MEMBER_OF"], 40)
             # A (seed) + B + C (2-hop causal) + concept + cluster.
             assert _ids(sg) == {A, B, C, CONCEPT, CLUSTER}
             # heterogeneous-node resolution: correct node types.
@@ -102,7 +113,7 @@ async def test_depth_bound(db_pool):
         await tr.start()
         try:
             await _seed(conn)
-            sg = await _subgraph(conn, [A], 1, None, 40)
+            sg = await _subgraph(conn, [A], 1, ["CAUSES", "INSTANCE_OF", "MEMBER_OF"], 40)
             # depth 1 from A reaches direct neighbours only: B, concept, cluster -- not C.
             assert _ids(sg) == {A, B, CONCEPT, CLUSTER}
             assert C not in _ids(sg)
@@ -144,6 +155,44 @@ async def test_empty_seed_returns_empty(db_pool):
         try:
             sg = await _subgraph(conn, [], 3, None, 40)
             assert sg["nodes"] == [] and sg["edges"] == []
+        finally:
+            await tr.rollback()
+
+
+async def test_archived_memory_drops_from_subgraph(db_pool):
+    """memory_edges is a derived store; `memories` is the source of truth. When
+    maintenance archives/prunes a memory, it -- and anything only reachable
+    through it -- must drop out of the subgraph without deleting any edge rows."""
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            ids = []
+            for content in ("A live", "B middle", "C downstream"):
+                ids.append(await conn.fetchval(
+                    "INSERT INTO memories (type, content, embedding, importance, trust_level, status) "
+                    "VALUES ('episodic', $1, array_fill(0.1, ARRAY[embedding_dimension()])::vector, 0.7, 0.9, 'active') "
+                    "RETURNING id", content))
+            A, B, C = ids
+            for s, d, w in ((A, B, 0.8), (B, C, 0.9)):
+                await conn.execute(
+                    "SELECT upsert_memory_edge('memory',$1::text,'CAUSES','memory',$2::text,$3::float,"
+                    "NULL::text,NULL::text,'{}'::jsonb)", str(s), str(d), w)
+
+            sg = _j(await conn.fetchval(
+                "SELECT build_context_subgraph($1::uuid[],3,ARRAY['CAUSES'],40)", [A]))
+            assert {n["id"] for n in sg["nodes"]} == {str(A), str(B), str(C)}
+
+            # Archive the middle memory (as consolidation/pruning would).
+            await conn.execute("UPDATE memories SET status='archived' WHERE id=$1", B)
+            sg2 = _j(await conn.fetchval(
+                "SELECT build_context_subgraph($1::uuid[],3,ARRAY['CAUSES'],40)", [A]))
+            ids2 = {n["id"] for n in sg2["nodes"]}
+            assert ids2 == {str(A)}           # B pruned; C unreachable through it
+            assert str(B) not in ids2
+            # The edge rows still exist -- only the read reflects liveness.
+            assert await conn.fetchval(
+                "SELECT count(*) FROM memory_edges WHERE rel_type='CAUSES'") == 2
         finally:
             await tr.rollback()
 


### PR DESCRIPTION
## Reflect live memories in the subgraph as maintenance prunes/consolidates

Follow-up to #26/#27, fixing a consistency gap: **`memory_edges` is a *derived* edge store, not a source of truth** — the `memories` table is. Memory maintenance (consolidation, reconsolidation, decay/pruning) constantly morphs the graph, soft-archiving memories (`status` active→archived/invalidated/redacted). `build_context_subgraph` had **no status filter**, so it would surface archived/consolidated/pruned memories — *less* consistent than the AGE readers it sits beside (which already do `WHERE m.status='active'`).

### Fix
- **`build_context_subgraph` filters to live memories** (`status='active'`, not past `valid_until`) at the endpoint level — during traversal, seeds, and output. Archiving a memory drops it **and anything only reachable through it**, without deleting any edge rows. So soft-archive stays reversible and the read always reflects the live `memories` table.
- **Mirror the last un-mirrored AGE edge delete**: resolving a contradiction removes the `CONTRADICTS` edge (`db/17`); now mirrored to `memory_edges` (both directions, since it's undirected). All four cypher edge-deletes are now covered (reconsolidation ×2, life-chapter via same-key upsert, contradiction-resolve).

### Why not prune edge rows?
There are no hard deletes (soft-archive only, kept "reversible and FK-safe"). Filtering at read time means stale edges are harmless and un-archiving just works — no GC needed. Orphaned edges (even from a hypothetical hard delete) are also excluded, since the endpoint won't be in the live set.

### Verification
`tests/db/test_memory_edges.py` gains `test_archived_memory_drops_from_subgraph` (archive a mid-chain memory → it + downstream vanish, edge rows persist). Clean rebuild; 27 graph/core/subconscious regressions green. Also corrected the existing subgraph tests, which had relied on non-existent memory ids — the liveness filter (correctly) excluded them, so they now seed real memories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved contradictions now remove both sides of the linked relationship, keeping the graph and related records in sync.
  * Context subgraphs now exclude archived or expired items, so readouts only show currently active content.

* **Tests**
  * Added coverage for archived items being pruned from subgraph results.
  * Updated subgraph tests to explicitly control relationship expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->