### PR TITLE
Add Mise and Colima development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ wheels/
 *.egg
 
 # Virtual Environment
+.venv/
 venv/
 env/
 ENV/

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Treat those statements as unverified.
 
 **Before you run anything**, you need:
 
-- [Docker Desktop](https://docs.docker.com/get-docker/) — installed **and running**
+- A running Docker daemon with Compose — [Docker Desktop](https://docs.docker.com/get-docker/), or Docker CLI + [Colima](https://github.com/abiosoft/colima) on macOS
 - The local embedding sidecar; `hexis init` starts the published `embeddinggemma` binary and downloads the ~300M-parameter model on first use
 - For the default path below: a **ChatGPT Plus/Pro subscription** (it authenticates via browser OAuth — no API key). No subscription? Use any provider under "Other providers."
 
@@ -127,7 +127,7 @@ The install script handles everything — it sets up [uv](https://docs.astral.sh
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | `hexis: command not found` after install | uv's tool directory isn't on PATH | `uv tool update-shell`, then open a new terminal |
-| `hexis init` stalls starting services | Docker daemon isn't running | Start Docker Desktop, re-run `hexis init` |
+| `hexis init` stalls starting services | Docker daemon isn't running | Start Docker Desktop or Colima, then re-run `hexis init` |
 | Embedding model pull fails | Local embedding sidecar isn't running | Start `embeddinggemma`, then re-run |
 | Browser login loops or model errors | No ChatGPT Plus/Pro on that account | Use another provider below, or `hexis auth` |
 | Anything else | — | `hexis doctor`, then [Troubleshooting](docs/operations/troubleshooting.md) |

--- a/apps/hexis_cli.py
+++ b/apps/hexis_cli.py
@@ -56,12 +56,18 @@ def _stack_root_from_compose(compose_file: Path) -> Path:
 def ensure_docker() -> str:
     docker_bin = shutil.which("docker")
     if not docker_bin:
-        _print_err("Docker is not installed or not on PATH. Install Docker Desktop: https://docs.docker.com/get-docker/")
+        _print_err(
+            "Docker is not installed or not on PATH. Install Docker Desktop, "
+            "or install the Docker CLI and a compatible daemon such as Colima."
+        )
         raise SystemExit(1)
     try:
         subprocess.run([docker_bin, "info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
     except subprocess.CalledProcessError:
-        _print_err("Docker is installed but not running. Start Docker Desktop and retry.")
+        _print_err(
+            "Docker is installed but no daemon is reachable. Start Docker Desktop "
+            "or run `colima start`, then retry."
+        )
         raise SystemExit(1)
     return docker_bin
 

--- a/docs/start/installation.md
+++ b/docs/start/installation.md
@@ -96,6 +96,21 @@ Note that `hexis` is then only on PATH while that virtualenv is active.
 
 For development or contributing:
 
+### With Mise
+
+The repository's [`mise.toml`](../../mise.toml) provides Python, uv, Bun, the Docker CLI, and Docker Compose. Install [Mise](https://mise.jdx.dev/getting-started.html), then run:
+
+```bash
+git clone https://github.com/QuixiAI/Hexis.git && cd Hexis
+mise install
+mise run setup
+mise run docker:check
+```
+
+`docker:check` uses whichever Docker daemon is active. On macOS without Docker Desktop, install and start the optional Colima runtime with `mise run docker:colima`, then rerun the check.
+
+### Without Mise
+
 ```bash
 git clone https://github.com/QuixiAI/Hexis.git && cd Hexis
 uv venv && source .venv/bin/activate

--- a/docs/start/installation.md
+++ b/docs/start/installation.md
@@ -107,7 +107,9 @@ mise run setup
 mise run docker:check
 ```
 
-`docker:check` uses whichever Docker daemon is active. On macOS without Docker Desktop, install and start the optional Colima runtime with `mise run docker:colima`, then rerun the check.
+`mise run setup` links the Mise-managed Compose binary into Docker's user plugin directory only when `docker compose` is otherwise unavailable; it never replaces an existing plugin. `docker:check` then verifies Compose through the standard `docker compose` command and uses whichever Docker daemon is active.
+
+On macOS 13 or newer without Docker Desktop, install and start the optional VZ/VirtioFS Colima runtime with `mise run docker:colima`, then rerun the check. On older macOS releases, use Docker Desktop or configure a compatible Docker daemon manually.
 
 ### Without Mise
 

--- a/docs/start/prerequisites.md
+++ b/docs/start/prerequisites.md
@@ -15,7 +15,7 @@ What you need before installing Hexis.
 
 | Dependency | Version | Purpose |
 |------------|---------|---------|
-| [Docker Desktop](https://docs.docker.com/get-docker/) | 20.10+ | Runs PostgreSQL (the agent's brain) |
+| Docker Engine + Compose | Docker 20.10+, Compose v2+ | Runs PostgreSQL (the agent's brain). Use [Docker Desktop](https://docs.docker.com/get-docker/) or the Docker CLI with [Colima](https://github.com/abiosoft/colima) on macOS |
 | [uv](https://docs.astral.sh/uv/) | Current | Installs the Hexis CLI into an isolated environment; downloads Python automatically if missing. The [install script](installation.md) sets it up for you |
 | Local embedding sidecar | Current | Generates embeddings for memory storage |
 
@@ -27,7 +27,7 @@ Installed is not enough — Docker's daemon and the embedding sidecar must both 
 
 ```bash
 docker --version          # Docker version 20.10+
-docker info               # daemon is running (errors if not — start Docker Desktop)
+docker info               # daemon is running (Docker Desktop, Colima, or Docker Engine)
 docker compose version    # Docker Compose v2+
 embeddinggemma --help
 uv --version              # or: python3 --version (3.10+) if managing Python yourself
@@ -63,7 +63,7 @@ See [Auth Providers](../integrations/auth/index.md) for setup details on each pr
 
 ## Platform Support
 
-Hexis runs on macOS, Linux, and Windows (via WSL2). Docker Desktop handles the PostgreSQL container across all platforms.
+Hexis runs on macOS, Linux, and Windows (via WSL2). It uses the active Docker context, so Docker Desktop and Colima both work without project-specific Compose changes.
 
 ## Next Steps
 

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -13,7 +13,7 @@ Get a running agent in 3 commands.
 
 ## Prerequisites
 
-- [Docker Desktop](https://docs.docker.com/get-docker/) -- installed **and running**
+- A running Docker daemon with Compose -- [Docker Desktop](https://docs.docker.com/get-docker/), or Docker CLI + [Colima](https://github.com/abiosoft/colima) on macOS
 - Local embedding sidecar -- `hexis init` starts it and downloads the ~300M-parameter embedding model on first use
 - For the default command below: a **ChatGPT Plus/Pro subscription** (browser OAuth, no API key). Without one, pick any provider from [Other Providers](#other-providers) instead.
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,60 @@
+[tools]
+# Python 3.12 matches the version used by CI and release builds.
+python = "3.12"
+uv = "0.12"
+bun = "1.4.0"
+# The CLI and Compose client work with either Docker Desktop or Colima.
+docker-cli = "29"
+docker-compose = "5"
+
+[tasks.setup]
+description = "Create the Python environment and install source dependencies"
+depends = ["setup:python", "setup:ui"]
+
+[tasks."setup:python"]
+hide = true
+run = '''
+if [ ! -x .venv/bin/python ]; then
+  uv venv --python 3.12
+fi
+uv pip install --python .venv/bin/python -e .
+if [ ! -f .env ]; then
+  cp .env.local .env
+fi
+'''
+
+[tasks."setup:ui"]
+hide = true
+dir = "hexis-ui"
+run = "bun install"
+
+[tasks."docker:check"]
+description = "Verify that a Docker daemon and Compose are available"
+run = '''
+if ! docker info >/dev/null 2>&1; then
+  echo "No Docker daemon is reachable. Start Docker Desktop, or on macOS run: mise run docker:colima" >&2
+  exit 1
+fi
+if ! docker compose version; then
+  docker-compose version
+fi
+'''
+
+[tasks."docker:colima"]
+description = "Install and start Colima as the Docker daemon on macOS"
+tools = { colima = "0.10.3", lima = "2.2.0" }
+run = '''
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "docker:colima is only supported on macOS." >&2
+  exit 1
+fi
+
+if docker info >/dev/null 2>&1; then
+  echo "A Docker daemon is already running; leaving it unchanged."
+  exit 0
+fi
+
+colima start --runtime docker --vm-type vz --mount-type virtiofs --cpu 4 --memory 8 --disk 60
+docker info >/dev/null
+echo "Colima is running and Docker is ready."
+'''

--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,7 @@ docker-compose = "5"
 
 [tasks.setup]
 description = "Create the Python environment and install source dependencies"
-depends = ["setup:python", "setup:ui"]
+depends = ["setup:python", "setup:ui", "setup:docker"]
 
 [tasks."setup:python"]
 hide = true
@@ -28,6 +28,25 @@ hide = true
 dir = "hexis-ui"
 run = "bun install"
 
+[tasks."setup:docker"]
+hide = true
+run = '''
+if ! docker compose version >/dev/null 2>&1; then
+  docker_config_dir="${DOCKER_CONFIG:-$HOME/.docker}"
+  compose_plugin_dir="$docker_config_dir/cli-plugins"
+  compose_plugin_path="$compose_plugin_dir/docker-compose"
+
+  if [ -e "$compose_plugin_path" ] || [ -L "$compose_plugin_path" ]; then
+    echo "Docker Compose is not discoverable, and a plugin already exists at $compose_plugin_path." >&2
+    exit 1
+  fi
+
+  mkdir -p "$compose_plugin_dir"
+  ln -s "$(mise which docker-compose)" "$compose_plugin_path"
+fi
+docker compose version
+'''
+
 [tasks."docker:check"]
 description = "Verify that a Docker daemon and Compose are available"
 run = '''
@@ -35,9 +54,7 @@ if ! docker info >/dev/null 2>&1; then
   echo "No Docker daemon is reachable. Start Docker Desktop, or on macOS run: mise run docker:colima" >&2
   exit 1
 fi
-if ! docker compose version; then
-  docker-compose version
-fi
+docker compose version
 '''
 
 [tasks."docker:colima"]
@@ -46,6 +63,13 @@ tools = { colima = "0.10.3", lima = "2.2.0" }
 run = '''
 if [ "$(uname -s)" != "Darwin" ]; then
   echo "docker:colima is only supported on macOS." >&2
+  exit 1
+fi
+
+macos_major="$(sw_vers -productVersion | cut -d. -f1)"
+if [ "$macos_major" -lt 13 ]; then
+  echo "docker:colima requires macOS 13 or newer for VZ and VirtioFS." >&2
+  echo "Use Docker Desktop or configure a compatible Docker daemon manually." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add a Mise-managed source toolchain for Python, uv, Bun, Docker CLI, and Docker Compose.
- Add idempotent source setup plus Docker health and optional Colima tasks.
- Treat Docker Desktop and Colima as equivalent Docker daemon options in CLI guidance and documentation.
- Ignore the documented .venv development environment.

## Rationale

Hexis already works through the active Docker context, but its prerequisites and error messages present Docker Desktop as mandatory. This gives contributors a reproducible Bun-first setup and an explicit Colima path without disrupting an existing Docker Desktop daemon.

## Verification

- mise run setup
- mise tasks validate
- mise run docker:check against Colima
- POSTGRES_HOST=127.0.0.1 pytest tests/cli/test_cli.py tests/cli/test_compose_defaults.py -q
- 15 tests passed

## Database impact

No schema changes and no database reset required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mise-based setup tasks for Python, UI dependencies, Docker checks, and optional Colima support on macOS.
  * Added support for Docker Engine with Compose v2, including Docker Desktop and Colima alternatives.
* **Documentation**
  * Updated installation, prerequisites, quickstart, and troubleshooting guidance for platform-neutral Docker setup.
  * Added separate source-install instructions for users with or without Mise.
* **Bug Fixes**
  * Improved Docker prerequisite and unavailable-daemon error messages.
* **Chores**
  * Added `.venv/` to ignored files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->