### PR TITLE
Fix dashboard polling feedback loops

### DIFF
--- a/hexis-ui/app/ingest/jobs.test.ts
+++ b/hexis-ui/app/ingest/jobs.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { isActiveIngestJob, mergeIngestJobs, normalizeIngestJob } from "./jobs";
+import {
+  isActiveIngestJob,
+  mergeIngestJobs,
+  normalizeIngestJob,
+  retainActiveTrackedJobIds,
+} from "./jobs";
 
 describe("ingest job helpers", () => {
   it("normalizes exact DB job rows by deriving display title from payload", () => {
@@ -48,5 +53,24 @@ describe("ingest job helpers", () => {
     expect(merged).toHaveLength(1);
     expect(merged[0].status).toBe("completed");
     expect(merged[0].result?.memories_created).toBe(5);
+  });
+
+  it("preserves tracked state identity when a poll finds no changes", () => {
+    const current = ["job-1"];
+    const exact = new Map([["job-1", { status: "in_progress" }]]);
+
+    expect(retainActiveTrackedJobIds(current, new Set(), exact)).toBe(current);
+  });
+
+  it("stops tracking completed and missing jobs", () => {
+    const current = ["active", "completed", "missing"];
+    const exact = new Map([
+      ["active", { status: "pending" }],
+      ["completed", { status: "completed" }],
+    ]);
+
+    expect(retainActiveTrackedJobIds(current, new Set(["missing"]), exact)).toEqual([
+      "active",
+    ]);
   });
 });

--- a/hexis-ui/app/ingest/jobs.ts
+++ b/hexis-ui/app/ingest/jobs.ts
@@ -92,3 +92,20 @@ export function mergeIngestJobs(
     .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
     .slice(0, limit);
 }
+
+export function retainActiveTrackedJobIds(
+  current: string[],
+  missingIds: ReadonlySet<string>,
+  exactById: ReadonlyMap<string, Pick<IngestJob, "status">>
+): string[] {
+  const next = current.filter((id) => {
+    if (missingIds.has(id)) return false;
+    const job = exactById.get(id);
+    return job ? isActiveIngestJob(job) : true;
+  });
+
+  // React compares state by reference. Preserve it when polling found no
+  // changes so consumers cannot accidentally turn a fetch effect into a
+  // render/fetch feedback loop.
+  return next.length === current.length ? current : next;
+}

--- a/hexis-ui/app/ingest/page.test.tsx
+++ b/hexis-ui/app/ingest/page.test.tsx
@@ -1,0 +1,67 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import IngestPage from "./page";
+
+describe("IngestPage polling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("loads once and waits for the idle polling interval", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ jobs: [] }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<IngestPage />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/ingest/jobs?limit=25", {
+      cache: "no-store",
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(14_999);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not overlap a slow jobs request", async () => {
+    let finishRequest: ((response: Response) => void) | undefined;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          finishRequest = resolve;
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<IngestPage />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      finishRequest?.(Response.json({ jobs: [] }));
+      await Promise.resolve();
+    });
+  });
+});

--- a/hexis-ui/app/ingest/page.tsx
+++ b/hexis-ui/app/ingest/page.tsx
@@ -21,6 +21,7 @@ import {
   isActiveIngestJob,
   mergeIngestJobs,
   normalizeIngestJob,
+  retainActiveTrackedJobIds,
 } from "./jobs";
 
 type PendingFileState = "queued" | "uploading" | "accepted" | "failed";
@@ -61,7 +62,13 @@ export default function IngestPage() {
   const [trackedJobIds, setTrackedJobIds] = useState<string[]>([]);
   const [jobsLoading, setJobsLoading] = useState(true);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const trackedJobIdsRef = useRef(trackedJobIds);
+  const jobsFetchInFlightRef = useRef(false);
   const hasActiveJobs = trackedJobIds.length > 0 || jobs.some(isActiveIngestJob);
+
+  useEffect(() => {
+    trackedJobIdsRef.current = trackedJobIds;
+  }, [trackedJobIds]);
 
   const trackAcceptedJob = useCallback((job: IngestJob) => {
     setJobs((prev) => mergeIngestJobs(prev, [job]));
@@ -71,64 +78,70 @@ export default function IngestPage() {
   }, []);
 
   const fetchJobs = useCallback(async () => {
+    if (jobsFetchInFlightRef.current) return;
+    jobsFetchInFlightRef.current = true;
+    const trackedIds = trackedJobIdsRef.current;
     const recentJobs: IngestJob[] = [];
     try {
-      const res = await fetch("/api/ingest/jobs?limit=25", { cache: "no-store" });
-      if (res.ok) {
-        const data = await res.json();
-        for (const item of Array.isArray(data.jobs) ? data.jobs : []) {
-          const job = normalizeIngestJob(item);
-          if (job) recentJobs.push(job);
-        }
-      }
-    } catch {
-      // Keep polling tracked jobs even when the recent-list proxy is unavailable.
-    }
-
-    const exactJobs: IngestJob[] = [];
-    const missingIds = new Set<string>();
-    await Promise.all(
-      trackedJobIds.map(async (id) => {
-        try {
-          const exact = await fetch(`/api/ingest/jobs/${encodeURIComponent(id)}`, {
-            cache: "no-store",
-          });
-          if (exact.status === 404) {
-            missingIds.add(id);
-            return;
+      try {
+        const res = await fetch("/api/ingest/jobs?limit=25", { cache: "no-store" });
+        if (res.ok) {
+          const data = await res.json();
+          for (const item of Array.isArray(data.jobs) ? data.jobs : []) {
+            const job = normalizeIngestJob(item);
+            if (job) recentJobs.push(job);
           }
-          if (!exact.ok) return;
-          const job = normalizeIngestJob(await exact.json());
-          if (job) exactJobs.push(job);
-        } catch {
-          // Keep the job tracked and visible; the next poll may succeed.
         }
-      })
-    );
+      } catch {
+        // Keep polling tracked jobs even when the recent-list proxy is unavailable.
+      }
 
-    const exactById = new Map(exactJobs.map((job) => [job.id, job]));
-    setTrackedJobIds((prev) =>
-      prev.filter((id) => {
-        if (missingIds.has(id)) return false;
-        const job = exactById.get(id);
-        return job ? isActiveIngestJob(job) : true;
-      })
-    );
-    setJobs((prev) => {
-      const unresolvedTracked = prev.filter(
-        (job) =>
-          trackedJobIds.includes(job.id) &&
-          !missingIds.has(job.id) &&
-          !exactById.has(job.id)
+      const exactJobs: IngestJob[] = [];
+      const missingIds = new Set<string>();
+      await Promise.all(
+        trackedIds.map(async (id) => {
+          try {
+            const exact = await fetch(`/api/ingest/jobs/${encodeURIComponent(id)}`, {
+              cache: "no-store",
+            });
+            if (exact.status === 404) {
+              missingIds.add(id);
+              return;
+            }
+            if (!exact.ok) return;
+            const job = normalizeIngestJob(await exact.json());
+            if (job) exactJobs.push(job);
+          } catch {
+            // Keep the job tracked and visible; the next poll may succeed.
+          }
+        })
       );
-      return mergeIngestJobs([...recentJobs, ...unresolvedTracked], exactJobs);
-    });
-    setJobsLoading(false);
-  }, [trackedJobIds]);
+
+      const exactById = new Map(exactJobs.map((job) => [job.id, job]));
+      setTrackedJobIds((prev) => retainActiveTrackedJobIds(prev, missingIds, exactById));
+      setJobs((prev) => {
+        const unresolvedTracked = prev.filter(
+          (job) =>
+            trackedIds.includes(job.id) &&
+            !missingIds.has(job.id) &&
+            !exactById.has(job.id)
+        );
+        return mergeIngestJobs([...recentJobs, ...unresolvedTracked], exactJobs);
+      });
+    } finally {
+      setJobsLoading(false);
+      jobsFetchInFlightRef.current = false;
+    }
+  }, []);
 
   useEffect(() => {
-    fetchJobs();
-    const timer = window.setInterval(fetchJobs, hasActiveJobs ? 3000 : 15000);
+    void fetchJobs();
+  }, [fetchJobs]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      void fetchJobs();
+    }, hasActiveJobs ? 3000 : 15000);
     return () => window.clearInterval(timer);
   }, [fetchJobs, hasActiveJobs]);
 

--- a/hexis-ui/app/responsibilities/page.test.tsx
+++ b/hexis-ui/app/responsibilities/page.test.tsx
@@ -1,0 +1,71 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ResponsibilitiesPage from "./page";
+
+describe("ResponsibilitiesPage polling", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/responsibilities") {
+          return Response.json({
+            status: { active: 1 },
+            responsibilities: [
+              {
+                id: "responsibility-1",
+                title: "Check the source",
+                kind: "monitor",
+                status: "active",
+                priority: "normal",
+                user_intent: "Watch for changes.",
+                trigger: {},
+                evaluator: {},
+                sources: [],
+                actions: [],
+                delivery: {},
+                memory_policy: "task_scoped",
+                timezone: "UTC",
+                next_check_at: null,
+                last_checked_at: null,
+                last_fired_at: null,
+                consecutive_errors: 0,
+                consecutive_silent: 0,
+                last_error: null,
+                created_at: null,
+              },
+            ],
+          });
+        }
+        if (url === "/api/responsibilities/responsibility-1") {
+          return Response.json({ responsibility: null });
+        }
+        return Response.json({}, { status: 404 });
+      }) as unknown as typeof fetch
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("selects the first result without restarting the list poll", async () => {
+    render(<ResponsibilitiesPage />);
+
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent("Check the source");
+    });
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/responsibilities/responsibility-1",
+        { cache: "no-store" }
+      );
+    });
+
+    const listCalls = vi
+      .mocked(fetch)
+      .mock.calls.filter(([input]) => String(input) === "/api/responsibilities");
+    expect(listCalls).toHaveLength(1);
+  });
+});

--- a/hexis-ui/app/responsibilities/page.tsx
+++ b/hexis-ui/app/responsibilities/page.tsx
@@ -12,7 +12,7 @@ import {
   Watch,
   type LucideIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
@@ -120,13 +120,17 @@ export default function ResponsibilitiesPage() {
       const data = (await response.json()) as ResponsibilitiesPayload;
       setPayload(data);
       setError(null);
-      if (!selectedId && data.responsibilities.length) setSelectedId(data.responsibilities[0].id);
+      setSelectedId((current) =>
+        current && data.responsibilities.some((item) => item.id === current)
+          ? current
+          : data.responsibilities[0]?.id ?? null
+      );
     } catch (requestError: unknown) {
       setError(requestError instanceof Error ? requestError.message : "Failed to load responsibilities.");
     } finally {
       setLoading(false);
     }
-  }, [filter, selectedId]);
+  }, [filter]);
 
   const fetchDetail = useCallback(async (id: string | null) => {
     if (!id) {
@@ -156,10 +160,8 @@ export default function ResponsibilitiesPage() {
   }, [fetchDetail, selectedId]);
 
   const responsibilities = payload?.responsibilities || [];
-  const selected = useMemo(
-    () => responsibilities.find((item) => item.id === selectedId) || detail?.responsibility || null,
-    [detail?.responsibility, responsibilities, selectedId]
-  );
+  const selected =
+    responsibilities.find((item) => item.id === selectedId) || detail?.responsibility || null;
 
   const runAction = async (action: string, args: JsonRecord = {}) => {
     const key = `${action}:${String(args.responsibility_id || args.title || "new")}`;
@@ -480,15 +482,13 @@ function ResponsibilityCard({
 }) {
   const blocked = item.status === "blocked";
   return (
-    <button
-      type="button"
-      onClick={onSelect}
+    <div
       className={`w-full rounded-md border bg-white p-4 text-left transition ${
         selected ? "border-[var(--teal)] shadow-sm" : "border-[var(--outline)] hover:border-[var(--teal)]/50"
       }`}
     >
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-        <div className="min-w-0">
+        <button type="button" onClick={onSelect} className="min-w-0 flex-1 text-left">
           <div className="flex flex-wrap items-center gap-2">
             <span className="font-semibold">{item.title}</span>
             <StatusBadge status={item.status} />
@@ -504,8 +504,8 @@ function ResponsibilityCard({
             <span>fired {shortDateTime(item.last_fired_at)}</span>
             {blocked && item.last_error ? <span className="text-red-700">{item.last_error}</span> : null}
           </div>
-        </div>
-        <div className="flex shrink-0 flex-wrap gap-2" onClick={(event) => event.stopPropagation()}>
+        </button>
+        <div className="flex shrink-0 flex-wrap gap-2">
           <IconButton label="Check now" disabled={Boolean(busy)} onClick={() => onAction("evaluate_now")}>
             <RefreshCw size={15} />
           </IconButton>
@@ -523,7 +523,7 @@ function ResponsibilityCard({
           </IconButton>
         </div>
       </div>
-    </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- stop the Ingest page from turning unchanged tracked-job state into an immediate render/fetch loop
- separate the initial jobs load from the adaptive 3s/15s polling timer
- prevent overlapping jobs requests when an earlier poll is still in flight
- keep the Responsibilities list poll stable when the initial selection changes
- replace invalid nested buttons in responsibility cards with sibling controls
- add regression coverage for polling cadence, in-flight deduplication, tracked-job reconciliation, and initial responsibility selection

## Similar-pattern audit

Audited every dashboard `setInterval` call and the related fetch callbacks. The OAuth session timer intentionally advances from server-returned session state without an immediate refetch or overlapping requests, so it was left unchanged. Other interval callbacks have stable dependencies. The Responsibilities list had the only additional state/callback feedback pattern, and its render test also exposed the nested-button hydration warning fixed here.

## Validation

- `bun run test` — 20 files, 58 tests passed
- `bunx eslint app/ingest/jobs.ts app/ingest/jobs.test.ts app/ingest/page.tsx app/ingest/page.test.tsx app/responsibilities/page.tsx app/responsibilities/page.test.tsx`
- `bun run build`

Repository-wide `bun run lint` still reports 22 pre-existing errors in untouched goals, settings, chat, and e2e files; all files changed by this PR pass ESLint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingestion job updates to keep active and unresolved jobs visible between refreshes.
  * Prevented overlapping polling requests and ensured job tracking continues even when recent-job retrieval fails.
  * Improved responsibility selection when items are added, removed, or unavailable.
  * Updated responsibility cards so action controls can be used without unintentionally changing the selected item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->